### PR TITLE
Remove default build_failure_grace_period_in_days

### DIFF
--- a/pkg/xray/resource_xray_license_policy.go
+++ b/pkg/xray/resource_xray_license_policy.go
@@ -192,7 +192,6 @@ func resourceXrayLicensePolicyV2() *schema.Resource {
 										Type:             schema.TypeInt,
 										Optional:         true,
 										Description:      "Allow grace period for certain number of days. All violations will be ignored during this time. To be used only if `fail_build` is enabled.",
-										Default:          3,
 										ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
 									},
 								},

--- a/pkg/xray/resource_xray_security_policy.go
+++ b/pkg/xray/resource_xray_security_policy.go
@@ -187,7 +187,6 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 									"build_failure_grace_period_in_days": {
 										Type:        schema.TypeInt,
 										Optional:    true,
-										Default:     3,
 										Description: "Allow grace period for certain number of days. All violations will be ignored during this time. To be used only if `fail_build` is enabled.",
 									},
 								},


### PR DESCRIPTION
API expects this value to only be set when `fail_build` is set to `true`.  But because there isa default value of `3` and when a fail_build is set to `false` OR not set at all, it errors out out.