### PR TITLE
Add all-builds to schema validation

### DIFF
--- a/pkg/xray/resource_xray_watch.go
+++ b/pkg/xray/resource_xray_watch.go
@@ -44,8 +44,8 @@ func resourceXrayWatch() *schema.Resource {
 						"type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							Description:      "Type of resource to be watched. Options: `all-repos`, `repository`, `build`, `project`, `all-projects`.",
-							ValidateDiagFunc: inList("all-repos", "repository", "build", "project", "all-projects"),
+							Description:      "Type of resource to be watched. Options: `all-repos`, `repository`, `all-builds`, `build`, `project`, `all-projects`.",
+							ValidateDiagFunc: inList("all-repos", "repository", "all-builds", "build", "project", "all-projects"),
 						},
 						"bin_mgr_id": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
It was possible to use terraform import to import a watch that we had created manually which used the **all-builds** type, but the provider fails to apply the configuration due to the schema validation.