### PR TITLE
Makefile, use the correct provider version in `make acceptance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 (Apr 15, 2022). Tested on Artifactory 7.37.13 and Xray 3.46.0
+## 1.1.0 (Apr 15, 2022). Tested on Artifactory 7.37.14 and Xray 3.47.3
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
Small change, adds the correct provider version for callhome when `make acceptance` runs