### PR TITLE
Switch to pass productId to shared module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1 (July 1, 2022)
+
+BUG FIXES:
+
+* provider: Fix hardcoded HTTP user-agent string. PR: [#62](https://github.com/jfrog/terraform-provider-xray/pull/62)
+
 ## 1.1.7 (June 21, 2022). Tested on Artifactory 7.39.4 and Xray 3.51.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1 (July 1, 2022)
+## 1.2.1 (July 1, 2022). Tested on Artifactory 7.39.4 and Xray 3.51.3
 
 BUG FIXES:
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/jfrog/terraform-provider-xray
 
+// if you need to do local dev, literally just uncomment the line below
+// replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
+
 require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v1.1.1
+	github.com/jfrog/terraform-provider-shared v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -144,10 +144,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v0.7.0 h1:x8qLXyptP35KC1vLaqN2AWJC7/eMNZE2jabiBx07JSY=
-github.com/jfrog/terraform-provider-shared v0.7.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
-github.com/jfrog/terraform-provider-shared v1.1.1 h1:/neab0fWIuwZ0X0M0dIbxYT5w6hdAUbWS0DTL/ZQxPw=
-github.com/jfrog/terraform-provider-shared v1.1.1/go.mod h1:8Ah3LHk0irA14Mq3t8uaYax+V+l9M4sKZXFcqoPtZkI=
+github.com/jfrog/terraform-provider-shared v1.4.0 h1:OVf0FxlTuDu5XlJM2IEvk+Sju4R/IP9mv5fAAB78GFE=
+github.com/jfrog/terraform-provider-shared v1.4.0/go.mod h1:8Ah3LHk0irA14Mq3t8uaYax+V+l9M4sKZXFcqoPtZkI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/xray/provider.go
+++ b/pkg/xray/provider.go
@@ -70,7 +70,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		return nil, diag.Errorf("you must supply a URL")
 	}
 
-	restyBase, err := client.Build(URL.(string), Version)
+	restyBase, err := client.Build(URL.(string), productId)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}


### PR DESCRIPTION
To ensure correct HTTP user-agent is used

Fixes jfrog/terraform-provider-shared#17