### PR TITLE
Ensure the `name` attribute is set on the `xray_watch` resource

### DIFF
--- a/pkg/xray/watches.go
+++ b/pkg/xray/watches.go
@@ -312,6 +312,9 @@ func packAssignedPolicies(policies []WatchAssignedPolicy) []interface{} {
 }
 
 func packWatch(ctx context.Context, watch Watch, d *schema.ResourceData) diag.Diagnostics {
+	if err := d.Set("name", watch.GeneralData.Name); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("description", watch.GeneralData.Description); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Performing a `terraform import` on an `xray_watch` resource fails to set the `name` attribute in the state file and hence, causes Terraform to want to re-create the resource on the next apply to correctly set the name.

Looking at the `xray_security_policy` (which does work), it appears that when packing the `watch`, the code was missing the assignment of the `name` attribute.

(See as per https://github.com/jfrog/terraform-provider-xray/blob/c7c60cc970811fdf214c2f1170d2a5dabdf59517/pkg/xray/policies.go#L620 in the `xray_security_policy`)