### PR TITLE
GH-84 handle unknown min severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.9.3 (November 24, 2022)
+## 1.9.3 (November 24, 2022). Tested on Artifactory 7.46.11 and Xray 3.61.5
 
 BUG FIX:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.9.3 (November 24, 2022)
+
+BUG FIX:
+
+* resource/xray_security_policy: fix `min_severity` attribute state drift due to Xray API bug, which has been fixed. Issue [#84](https://github.com/jfrog/terraform-provider-xray/issues/84) PR [#90](https://github.com/jfrog/terraform-provider-xray/pull/90)
+
 ## 1.9.2 (November 22, 2022)
 
 BUG FIX:

--- a/pkg/xray/policies.go
+++ b/pkg/xray/policies.go
@@ -570,7 +570,15 @@ func packSecurityCriteria(criteria *PolicyRuleCriteria) []interface{} {
 	m := map[string]interface{}{}
 	// cvss_range and min_severity are conflicting, only one can be present in the JSON
 	m["cvss_range"] = packCVSSRange(criteria.CVSSRange)
-	m["min_severity"] = criteria.MinimumSeverity
+
+	minSeverity := criteria.MinimumSeverity
+	// This is only needed for versions before 3.60.2 because a Xray API bug where it returns "Unknown" for "All severities" min severity setting
+	// See release note: https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.60.2
+	// Issue: XRAY-9271
+	if criteria.MinimumSeverity == "Unknown" {
+		minSeverity = "All severities"
+	}
+	m["min_severity"] = minSeverity
 	m["fix_version_dependant"] = criteria.FixVersionDependant
 
 	return []interface{}{m}


### PR DESCRIPTION
Fixes #84

Add patch code for `min_severity` due to Xray API bug in <3.60.2. Include new test that only executes when Xray version is prior to 3.60.2.

This breaks from our convention that the provider only support latest version of Xray. Since the API bug has already been fixed in theory this patch is unnecessary. However, I think this patch will be useful for customers who aren't yet ready/won't upgrade Xray in immediate future.