### PR TITLE
Ensure the `watch_recipients` attribute is set on the `xray_watch` resource

### DIFF
--- a/pkg/xray/watches.go
+++ b/pkg/xray/watches.go
@@ -327,6 +327,9 @@ func packWatch(ctx context.Context, watch Watch, d *schema.ResourceData) diag.Di
 	if err := d.Set("assigned_policy", packAssignedPolicies(watch.AssignedPolicies)); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("watch_recipients", watch.WatchRecipients); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Performing a terraform import on an `xray_watch` resource fails to set the `watch_recipients` attribute values in the state file and hence, causes Terraform to always want to update the watch recipients.

This is a similar issue as https://github.com/jfrog/terraform-provider-xray/pull/88