### PR TITLE
PTRENG-5027 use the latest shared module for project verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.1 (March 28, 2023).
+
+IMPROVEMENTS:
+* `project_key` attribute validation for all the resources has been changed to match Artifactory requirements since 7.56.2 - the length should be between 2-32 characters.
+  PR: [#]()
+
 ## 1.11.0 (March 22, 2023). Tested on Artifactory 7.55.8 and Xray 3.69.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 * `project_key` attribute validation for all the resources has been changed to match Artifactory requirements since 7.56.2 - the length should be between 2-32 characters.
-  PR: [#]()
+  PR: [#113](https://github.com/jfrog/terraform-provider-xray/pull/113)
 
 ## 1.11.0 (March 22, 2023). Tested on Artifactory 7.55.8 and Xray 3.69.3
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v1.11.1
+	github.com/jfrog/terraform-provider-shared v1.13.0
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	golang.org/x/text v0.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v1.13.0
+	github.com/jfrog/terraform-provider-shared v1.14.0
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	golang.org/x/text v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.13.0 h1:U492Yq6YeTF02ZVmwHfr9YcAUGM+Nqk7/EQnGHiOL6I=
-github.com/jfrog/terraform-provider-shared v1.13.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
+github.com/jfrog/terraform-provider-shared v1.14.0 h1:C9EGwZKLAtzts543zpXANjYYwM3/pX64H7oMbhimA8g=
+github.com/jfrog/terraform-provider-shared v1.14.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.11.1 h1:oRK5c5Rt0wYTKrRqr+t+fspDPgn/PT5TKjCzxehfoz0=
-github.com/jfrog/terraform-provider-shared v1.11.1/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
+github.com/jfrog/terraform-provider-shared v1.13.0 h1:U492Yq6YeTF02ZVmwHfr9YcAUGM+Nqk7/EQnGHiOL6I=
+github.com/jfrog/terraform-provider-shared v1.13.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/xray/policies.go
+++ b/pkg/xray/policies.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -663,7 +662,7 @@ func resourceXrayPolicyCreate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	req, err := getRestyRequest(m.(*resty.Client), policy.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, policy.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -681,7 +680,7 @@ func resourceXrayPolicyRead(ctx context.Context, d *schema.ResourceData, m inter
 	policy := Policy{}
 
 	projectKey := d.Get("project_key").(string)
-	req, err := getRestyRequest(m.(*resty.Client), projectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, projectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -708,7 +707,7 @@ func resourceXrayPolicyUpdate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	req, err := getRestyRequest(m.(*resty.Client), policy.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, policy.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -733,7 +732,7 @@ func resourceXrayPolicyDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	req, err := getRestyRequest(m.(*resty.Client), policy.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, policy.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/xray/provider.go
+++ b/pkg/xray/provider.go
@@ -103,9 +103,17 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		}
 	}
 
+	version, err := util.GetArtifactoryVersion(restyBase)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	featureUsage := fmt.Sprintf("Terraform/%s", terraformVersion)
 	util.SendUsage(ctx, restyBase, productId, featureUsage)
 
-	return restyBase, nil
+	return util.ProvderMetadata{
+		Client:             restyBase,
+		ArtifactoryVersion: version,
+	}, nil
 
 }

--- a/pkg/xray/reports.go
+++ b/pkg/xray/reports.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -629,7 +628,7 @@ func resourceXrayReportRead(ctx context.Context, d *schema.ResourceData, m inter
 	report := Report{}
 
 	projectKey := d.Get("project_key").(string)
-	req, err := getRestyRequest(m.(*resty.Client), projectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, projectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -651,7 +650,7 @@ func resourceXrayReportRead(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceXrayReportDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	projectKey := d.Get("project_key").(string)
-	req, err := getRestyRequest(m.(*resty.Client), projectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, projectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -670,7 +669,7 @@ func resourceXrayReportDelete(_ context.Context, d *schema.ResourceData, m inter
 
 func createReport(reportType string, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	report := unpackReport(d, reportType)
-	req, err := getRestyRequest(m.(*resty.Client), report.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, report.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/xray/resource_xray_ignore_rule.go
+++ b/pkg/xray/resource_xray_ignore_rule.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -469,7 +468,7 @@ func resourceXrayIgnoreRule() *schema.Resource {
 		ignoreRule := IgnoreRule{}
 
 		projectKey := d.Get("project_key").(string)
-		req, err := getRestyRequest(m.(*resty.Client), projectKey)
+		req, err := getRestyRequest(m.(util.ProvderMetadata).Client, projectKey)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -497,7 +496,7 @@ func resourceXrayIgnoreRule() *schema.Resource {
 			return diag.FromErr(err)
 		}
 
-		req, err := getRestyRequest(m.(*resty.Client), ignoreRule.ProjectKey)
+		req, err := getRestyRequest(m.(util.ProvderMetadata).Client, ignoreRule.ProjectKey)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -536,7 +535,7 @@ func resourceXrayIgnoreRule() *schema.Resource {
 			return diag.FromErr(err)
 		}
 
-		req, err := getRestyRequest(m.(*resty.Client), ignoreRule.ProjectKey)
+		req, err := getRestyRequest(m.(util.ProvderMetadata).Client, ignoreRule.ProjectKey)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/xray/resource_xray_repository_config.go
+++ b/pkg/xray/resource_xray_repository_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -289,7 +288,7 @@ func resourceXrayRepositoryConfig() *schema.Resource {
 	var resourceXrayRepositoryConfigRead = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		repositoryConfig := RepositoryConfiguration{}
 
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetResult(&repositoryConfig).
 			SetPathParam("repo_name", d.Id()).
 			Get("xray/api/v1/repos_config/{repo_name}")
@@ -308,7 +307,7 @@ func resourceXrayRepositoryConfig() *schema.Resource {
 	var resourceXrayRepositoryConfigCreate = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		repositoryConfig := unpackRepositoryConfig(d)
 
-		_, err := m.(*resty.Client).R().SetBody(&repositoryConfig).Put("xray/api/v1/repos_config")
+		_, err := m.(util.ProvderMetadata).Client.R().SetBody(&repositoryConfig).Put("xray/api/v1/repos_config")
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/xray/resource_xray_settings.go
+++ b/pkg/xray/resource_xray_settings.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -55,7 +54,7 @@ func packDBSyncTime(dbSyncTime DbSyncDailyUpdatesTime, d *schema.ResourceData) d
 
 func resourceXrayDbSyncTimeRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	dbSyncTime := DbSyncDailyUpdatesTime{}
-	resp, err := m.(*resty.Client).R().SetResult(&dbSyncTime).Get("xray/api/v1/configuration/dbsync/time")
+	resp, err := m.(util.ProvderMetadata).Client.R().SetResult(&dbSyncTime).Get("xray/api/v1/configuration/dbsync/time")
 	if err != nil {
 		if resp != nil && resp.StatusCode() != http.StatusOK {
 			log.Printf("Critical error. DB sync settings (%s) not found.", d.Id())
@@ -68,7 +67,7 @@ func resourceXrayDbSyncTimeRead(_ context.Context, d *schema.ResourceData, m int
 
 func resourceXrayDbSyncTimeUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	dbSyncTime := unpackDBSyncTime(d)
-	_, err := m.(*resty.Client).R().SetBody(dbSyncTime).Put("xray/api/v1/configuration/dbsync/time")
+	_, err := m.(util.ProvderMetadata).Client.R().SetBody(dbSyncTime).Put("xray/api/v1/configuration/dbsync/time")
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/xray/resource_xray_workers_count.go
+++ b/pkg/xray/resource_xray_workers_count.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -220,7 +219,7 @@ func resourceXrayWorkersCount() *schema.Resource {
 
 	var resourceXrayWorkersCountRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		workersCount := WorkersCount{}
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetResult(&workersCount).
 			Get("xray/api/v1/configuration/workersCount")
 		if err != nil {
@@ -235,7 +234,7 @@ func resourceXrayWorkersCount() *schema.Resource {
 
 	var resourceXrayWorkersCountUpdate = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		workersCount := unpackWorkersCount(d)
-		_, err := m.(*resty.Client).R().
+		_, err := m.(util.ProvderMetadata).Client.R().
 			SetBody(workersCount).
 			Put("xray/api/v1/configuration/workersCount")
 

--- a/pkg/xray/util_test.go
+++ b/pkg/xray/util_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func checkPolicy(id string, request *resty.Request) (*resty.Response, error) {
@@ -38,7 +39,7 @@ func verifyDeleted(id string, check CheckFun) func(*terraform.State) error {
 		}
 		provider, _ := testAccProviders()["xray"]()
 		provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
-		c := provider.Meta().(*resty.Client)
+		c := provider.Meta().(util.ProvderMetadata).Client
 		resp, err := check(rs.Primary.ID, c.R())
 		if err != nil {
 			if resp != nil {

--- a/pkg/xray/watches.go
+++ b/pkg/xray/watches.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -394,7 +393,7 @@ func packWatch(ctx context.Context, watch Watch, d *schema.ResourceData) diag.Di
 func resourceXrayWatchCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	watch := unpackWatch(d)
 
-	req, err := getRestyRequest(m.(*resty.Client), watch.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, watch.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -424,7 +423,7 @@ func resourceXrayWatchRead(ctx context.Context, d *schema.ResourceData, m interf
 	watch := Watch{}
 
 	projectKey := d.Get("project_key").(string)
-	req, err := getRestyRequest(m.(*resty.Client), projectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, projectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -449,7 +448,7 @@ func resourceXrayWatchRead(ctx context.Context, d *schema.ResourceData, m interf
 func resourceXrayWatchUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	watch := unpackWatch(d)
 
-	req, err := getRestyRequest(m.(*resty.Client), watch.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, watch.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -475,7 +474,7 @@ func resourceXrayWatchUpdate(ctx context.Context, d *schema.ResourceData, m inte
 func resourceXrayWatchDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	watch := unpackWatch(d)
 
-	req, err := getRestyRequest(m.(*resty.Client), watch.ProjectKey)
+	req, err := getRestyRequest(m.(util.ProvderMetadata).Client, watch.ProjectKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Artifactory 7.56.2 expands the maximum length for the project key to 32.
Use the latest shared module with an updated verification function.