### PR TITLE
GH-112 add vulnerability_ids attribute to security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.12.0 (April, 11, 2023).
+
+IMPROVEMENTS:
+
+* resource/xray_security_policy: added new security policy rule criteria `vulnerability_ids`, which allows to create a policy with criteria type Vulnerabilities and include a list of a specific CVEs.
+ Issue: [#112](https://github.com/jfrog/terraform-provider-xray/issues/112)
+ PR: [#]()
+
 ## 1.11.1 (March 28, 2023). Tested on Artifactory 7.55.9 and Xray 3.69.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 
 * resource/xray_security_policy: added new security policy rule criteria `vulnerability_ids`, which allows to create a policy with criteria type Vulnerabilities and include a list of a specific CVEs.
  Issue: [#112](https://github.com/jfrog/terraform-provider-xray/issues/112)
- PR: [#]()
+ PR: [#116](https://github.com/jfrog/terraform-provider-xray/pull/116)
 
 ## 1.11.1 (March 28, 2023). Tested on Artifactory 7.55.9 and Xray 3.69.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.12.0 (April, 11, 2023).
+## 1.12.0 (April, 11, 2023). Tested on Artifactory 7.55.10 and Xray 3.69.3
 
 IMPROVEMENTS:
 

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -162,6 +162,7 @@ Optional:
 - `fix_version_dependant` (Boolean) Default value is `false`. Issues that do not have a fixed version are not generated until a fixed version is available. Must be `false` with `malicious_package` enabled.
 - `malicious_package` (Boolean) Default value is `false`. Generating a violation on a malicious package.
 - `min_severity` (String) The minimum security vulnerability severity that will be impacted by the policy.
+- `vulnerability_ids` (Set of String) Creates policy rules for specific vulnerability IDs that you input. You can add multiple vulnerabilities IDs up to 100, separated by ",". CVEs and Xray IDs are supported. Example - CVE-2015-20107, XRAY-2344
 
 <a id="nestedblock--rule--criteria--cvss_range"></a>
 ### Nested Schema for `rule.criteria.cvss_range`

--- a/pkg/xray/resource_xray_security_policy.go
+++ b/pkg/xray/resource_xray_security_policy.go
@@ -3,6 +3,7 @@ package xray
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -51,6 +52,19 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 				},
 			},
 		},
+		"vulnerability_ids": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Set:         schema.HashString,
+			Description: "Creates policy rules for specific vulnerability IDs that you input. You can add multiple vulnerabilities IDs up to 100, separated by \",\". CVEs and Xray IDs are supported. Example - CVE-2015-20107, XRAY-2344",
+			Elem: &schema.Schema{
+				Type:     schema.TypeString,
+				MaxItems: 100,
+				ValidateDiagFunc: validation.ToDiagFunc(
+					validation.StringMatch(regexp.MustCompile(`(CVE-\d\d\d\d-\d+|XRAY-\d+)`), "invalid Vulnerability, must be a valid CVE or Xray ID, example CVE-2021-12345, XRAY-1234"),
+				),
+			},
+		},
 	}
 
 	return &schema.Resource{
@@ -85,6 +99,7 @@ var criteriaMaliciousPkgDiff = func(ctx context.Context, diff *schema.ResourceDi
 	fixVersionDependant := criterion["fix_version_dependant"].(bool)
 	minSeverity := criterion["min_severity"].(string)
 	cvssRange := criterion["cvss_range"].([]interface{})
+	vulnerabilityIDs := criterion["vulnerability_ids"].(*schema.Set).List()
 	// If `malicious_package` is enabled in the UI, `fix_version_dependant` is set to `false` in the UI call.
 	// UI itself doesn't have this checkbox at all. We are adding this check to avoid unexpected behavior.
 	if maliciousPackage && fixVersionDependant {
@@ -95,6 +110,13 @@ var criteriaMaliciousPkgDiff = func(ctx context.Context, diff *schema.ResourceDi
 	}
 	if len(minSeverity) > 0 && len(cvssRange) > 0 {
 		return fmt.Errorf("min_severity can't be set together with cvss_range")
+	}
+	if (len(vulnerabilityIDs) > 0 && maliciousPackage) || (len(vulnerabilityIDs) > 0 && len(minSeverity) > 0) ||
+		(len(vulnerabilityIDs) > 0 && len(cvssRange) > 0) {
+		return fmt.Errorf("vulnerability_ids can't be set together with with malicious_package, min_severity and/or cvss_range")
+	}
+	if len(vulnerabilityIDs) > 99 {
+		return fmt.Errorf("vulnerability_ids can contains at least 1 and no more than 100 vulnerabilities Ids")
 	}
 
 	return nil

--- a/pkg/xray/resource_xray_security_policy.go
+++ b/pkg/xray/resource_xray_security_policy.go
@@ -55,13 +55,13 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 		"vulnerability_ids": {
 			Type:        schema.TypeSet,
 			Optional:    true,
-			Set:         schema.HashString,
-			Description: "Creates policy rules for specific vulnerability IDs that you input. You can add multiple vulnerabilities IDs up to 100, separated by \",\". CVEs and Xray IDs are supported. Example - CVE-2015-20107, XRAY-2344",
+			MaxItems:    100,
+			MinItems:    1,
+			Description: "Creates policy rules for specific vulnerability IDs that you input. You can add multiple vulnerabilities IDs up to 100. CVEs and Xray IDs are supported. Example - CVE-2015-20107, XRAY-2344",
 			Elem: &schema.Schema{
-				Type:     schema.TypeString,
-				MaxItems: 100,
+				Type: schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(
-					validation.StringMatch(regexp.MustCompile(`(CVE-\d\d\d\d-\d+|XRAY-\d+)`), "invalid Vulnerability, must be a valid CVE or Xray ID, example CVE-2021-12345, XRAY-1234"),
+					validation.StringMatch(regexp.MustCompile(`(CVE\W*\d{4}\W+\d{4,}|XRAY-\d{4,})`), "invalid Vulnerability, must be a valid CVE or Xray ID, example CVE-2021-12345, XRAY-1234"),
 				),
 			},
 		},
@@ -114,9 +114,6 @@ var criteriaMaliciousPkgDiff = func(ctx context.Context, diff *schema.ResourceDi
 	if (len(vulnerabilityIDs) > 0 && maliciousPackage) || (len(vulnerabilityIDs) > 0 && len(minSeverity) > 0) ||
 		(len(vulnerabilityIDs) > 0 && len(cvssRange) > 0) {
 		return fmt.Errorf("vulnerability_ids can't be set together with with malicious_package, min_severity and/or cvss_range")
-	}
-	if len(vulnerabilityIDs) > 99 {
-		return fmt.Errorf("vulnerability_ids can contains at least 1 and no more than 100 vulnerabilities Ids")
 	}
 
 	return nil

--- a/pkg/xray/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource_xray_security_policy_test.go
@@ -628,7 +628,7 @@ func TestAccSecurityPolicy_vulnerabilityIdsConflictingAttributesFail(t *testing.
 func TestAccSecurityPolicy_vulnerabilityIdsLimitFail(t *testing.T) {
 	_, fqrn, resourceName := test.MkNames("policy-", "xray_security_policy")
 	testData := util.MergeMaps(testDataSecurity)
-	CVEString := generateListOfNames("CVE-2022-", 102)
+	CVEString := generateListOfNames("CVE-2022-", 101)
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-9-%d", test.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-9-%d", test.RandomInt())

--- a/pkg/xray/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource_xray_security_policy_test.go
@@ -566,7 +566,7 @@ func TestAccSecurityPolicy_vulnerabilityIdsIncorrectCVEFails(t *testing.T) {
 	_, fqrn, resourceName := test.MkNames("policy-", "xray_security_policy")
 	testData := util.MergeMaps(testDataSecurity)
 
-	for _, invalidCVE := range []string{"CVE-20211-67890", "Xray-12345", "cve-2021-67890", "CVE-11-67890"} {
+	for _, invalidCVE := range []string{"CVE-20211-67890", "CVE-2021-678", "Xray-12345", "cve-2021-67890", "CVE-11-67890", "XRAY-1"} {
 		testData["resource_name"] = resourceName
 		testData["policy_name"] = fmt.Sprintf("terraform-security-policy-9-%d", test.RandomInt())
 		testData["rule_name"] = fmt.Sprintf("test-security-rule-9-%d", test.RandomInt())
@@ -628,7 +628,7 @@ func TestAccSecurityPolicy_vulnerabilityIdsConflictingAttributesFail(t *testing.
 func TestAccSecurityPolicy_vulnerabilityIdsLimitFail(t *testing.T) {
 	_, fqrn, resourceName := test.MkNames("policy-", "xray_security_policy")
 	testData := util.MergeMaps(testDataSecurity)
-	CVEString := generateListOfNames("CVE-2022-", 101)
+	CVEString := generateListOfNames("CVE-2022-", 102)
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-9-%d", test.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-9-%d", test.RandomInt())
@@ -643,7 +643,7 @@ func TestAccSecurityPolicy_vulnerabilityIdsLimitFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      util.ExecuteTemplate(fqrn, securityPolicyVulnIdsLimit, testData),
-				ExpectError: regexp.MustCompile("vulnerability_ids can contains at least 1 and no more than 100 vulnerabilities Ids"),
+				ExpectError: regexp.MustCompile("Too many list items"),
 			},
 		},
 	})

--- a/pkg/xray/util_test.go
+++ b/pkg/xray/util_test.go
@@ -111,3 +111,13 @@ func DeleteProject(t *testing.T, projectKey string) {
 		t.Fatal(err)
 	}
 }
+
+func generateListOfNames(prefix string, number int) string {
+	var CVEs []string
+	n := 1
+	for n < number {
+		CVEs = append(CVEs, fmt.Sprintf("\"%s%d\",", prefix, test.RandomInt()))
+		n++
+	}
+	return fmt.Sprintf("%s", CVEs)
+}

--- a/pkg/xray/util_test.go
+++ b/pkg/xray/util_test.go
@@ -114,7 +114,7 @@ func DeleteProject(t *testing.T, projectKey string) {
 
 func generateListOfNames(prefix string, number int) string {
 	var CVEs []string
-	n := 1
+	n := 0
 	for n < number {
 		CVEs = append(CVEs, fmt.Sprintf("\"%s%d\",", prefix, test.RandomInt()))
 		n++


### PR DESCRIPTION
Add tests and update documentation. `vulnerability_ids` allows to create a policy with criteria type Vulnerabilities and include a list of a specific CVEs