### PR TITLE
PTRENG-5020 add exposures criteria to security policies.

### DIFF
--- a/.jfrog-pipelines/TFproviderTest.yml
+++ b/.jfrog-pipelines/TFproviderTest.yml
@@ -279,7 +279,7 @@ pipelines:
             - echo "Success"
             - echo "All tests passed successfully."
             - export STATE="success"
-            - export DESCRIPTION="Pipeline has failed."
+            - export DESCRIPTION="All tests passed successfully."
             - cd ${res_terraform_provider_shared_resourcePath}
             - ./scripts/github-status.sh ${res_terraform_provider_xray_gitProvider_token} ${res_terraform_provider_xray_gitRepoFullName} ${res_terraform_provider_xray_commitSha} && cd ${PWD}
             - >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 1.12.0 (April, 11, 2023). Tested on Artifactory 7.55.10 and Xray 3.69.3
+## 1.13.0 (April 19, 2023).
+
+IMPROVEMENTS:
+
+* resource/xray_security_policy: added new security policy rule criteria `exposures`, which allows to create a policy with criteria type Exposures and include specific exposures. Works only with [JFrog Advanced Security](https://jfrog.com/advanced-security/) license, otherwise the block will be ignored by API.
+ PR: [#]()
+
+## 1.12.0 (April 11, 2023). Tested on Artifactory 7.55.10 and Xray 3.69.3
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * resource/xray_security_policy: added new security policy rule criteria `exposures`, which allows to create a policy with criteria type Exposures and include specific exposures. Works only with [JFrog Advanced Security](https://jfrog.com/advanced-security/) license, otherwise the block will be ignored by API.
- PR: [#]()
+ PR: [#118](https://github.com/jfrog/terraform-provider-xray/pull/118)
 
 ## 1.12.0 (April 11, 2023). Tested on Artifactory 7.55.10 and Xray 3.69.3
 

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -159,6 +159,7 @@ Optional:
 Optional:
 
 - `cvss_range` (Block List, Max: 1) The CVSS score range to apply to the rule. This is used for a fine-grained control, rather than using the predefined severities. The score range is based on CVSS v3 scoring, and CVSS v2 score is CVSS v3 score is not available. (see [below for nested schema](#nestedblock--rule--criteria--cvss_range))
+- `exposures` (Block List, Max: 1) Works only with [JFrog Advanced Security](https://jfrog.com/advanced-security/) license. Creates policy rules for specific exposures. (see [below for nested schema](#nestedblock--rule--criteria--exposures))
 - `fix_version_dependant` (Boolean) Default value is `false`. Issues that do not have a fixed version are not generated until a fixed version is available. Must be `false` with `malicious_package` enabled.
 - `malicious_package` (Boolean) Default value is `false`. Generating a violation on a malicious package.
 - `min_severity` (String) The minimum security vulnerability severity that will be impacted by the policy.
@@ -171,6 +172,18 @@ Required:
 
 - `from` (Number) The beginning of the range of CVS scores (from 1-10, float) to flag.
 - `to` (Number) The end of the range of CVS scores (from 1-10, float) to flag.
+
+
+<a id="nestedblock--rule--criteria--exposures"></a>
+### Nested Schema for `rule.criteria.exposures`
+
+Optional:
+
+- `applications` (Boolean) Applications exposures.
+- `iac` (Boolean) Iac exposures.
+- `min_severity` (String) The minimum security vulnerability severity that will be impacted by the policy.
+- `secrets` (Boolean) Secrets exposures.
+- `services` (Boolean) Services exposures.
 
 
 

--- a/pkg/xray/resource_xray_security_policy.go
+++ b/pkg/xray/resource_xray_security_policy.go
@@ -65,6 +65,47 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 				),
 			},
 		},
+		"exposures": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Works only with JFrog Advanced Security license. Creates policy rules for specific exposures.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"min_severity": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Default:          "All Severities",
+						Description:      "The minimum security vulnerability severity that will be impacted by the policy.",
+						ValidateDiagFunc: validator.StringInSlice(true, "All Severities", "Critical", "High", "Medium", "Low"),
+					},
+					"secrets": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Secrets exposures.",
+					},
+					"applications": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Applications exposures.",
+					},
+					"services": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Services exposures.",
+					},
+					"iac": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Iac exposures.",
+					},
+				},
+			},
+		},
 	}
 
 	return &schema.Resource{
@@ -95,25 +136,33 @@ var criteriaMaliciousPkgDiff = func(ctx context.Context, diff *schema.ResourceDi
 	}
 
 	criterion := criteria[0].(map[string]interface{})
-	maliciousPackage := criterion["malicious_package"].(bool)
+	// fixVersionDependant can't be set with malicious_package
 	fixVersionDependant := criterion["fix_version_dependant"].(bool)
+	// Only one of the following:
 	minSeverity := criterion["min_severity"].(string)
 	cvssRange := criterion["cvss_range"].([]interface{})
 	vulnerabilityIDs := criterion["vulnerability_ids"].(*schema.Set).List()
+	maliciousPackage := criterion["malicious_package"].(bool)
+	exposures := criterion["exposures"].([]interface{})
+
+	if len(exposures) > 0 && maliciousPackage || (len(exposures) > 0 && len(cvssRange) > 0) ||
+		(len(exposures) > 0 && len(minSeverity) > 0) || (len(exposures) > 0 && len(vulnerabilityIDs) > 0) {
+		return fmt.Errorf("exsposures can't be set together with cvss_range, min_severity, malicious_package and vulnerability_ids")
+	}
 	// If `malicious_package` is enabled in the UI, `fix_version_dependant` is set to `false` in the UI call.
 	// UI itself doesn't have this checkbox at all. We are adding this check to avoid unexpected behavior.
 	if maliciousPackage && fixVersionDependant {
 		return fmt.Errorf("fix_version_dependant must be set to false if malicious_package is true")
 	}
-	if (maliciousPackage && len(minSeverity) > 0) && (maliciousPackage && len(cvssRange) > 0) {
-		return fmt.Errorf("malicious_package can't be set to true together with min_severity and/or cvss_range")
+	if (maliciousPackage && len(minSeverity) > 0) || (maliciousPackage && len(cvssRange) > 0) {
+		return fmt.Errorf("malicious_package can't be set together with min_severity and/or cvss_range")
 	}
 	if len(minSeverity) > 0 && len(cvssRange) > 0 {
 		return fmt.Errorf("min_severity can't be set together with cvss_range")
 	}
 	if (len(vulnerabilityIDs) > 0 && maliciousPackage) || (len(vulnerabilityIDs) > 0 && len(minSeverity) > 0) ||
-		(len(vulnerabilityIDs) > 0 && len(cvssRange) > 0) {
-		return fmt.Errorf("vulnerability_ids can't be set together with with malicious_package, min_severity and/or cvss_range")
+		(len(vulnerabilityIDs) > 0 && len(cvssRange) > 0) || (len(vulnerabilityIDs) > 0 && len(exposures) > 0) {
+		return fmt.Errorf("vulnerability_ids can't be set together with with malicious_package, min_severity, cvss_range and exposures")
 	}
 
 	return nil

--- a/pkg/xray/resource_xray_security_policy.go
+++ b/pkg/xray/resource_xray_security_policy.go
@@ -15,7 +15,7 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 		"min_severity": {
 			Type:             schema.TypeString,
 			Optional:         true,
-			Description:      "The minimum security vulnerability severity that will be impacted by the policy.",
+			Description:      "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All Severities`, `Critical`, `High`, `Medium`, `Low`",
 			ValidateDiagFunc: validator.StringInSlice(true, "All Severities", "Critical", "High", "Medium", "Low"),
 		},
 		"fix_version_dependant": {
@@ -76,7 +76,7 @@ func resourceXraySecurityPolicyV2() *schema.Resource {
 						Type:             schema.TypeString,
 						Optional:         true,
 						Default:          "All Severities",
-						Description:      "The minimum security vulnerability severity that will be impacted by the policy.",
+						Description:      "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All Severities`, `Critical`, `High`, `Medium`, `Low`",
 						ValidateDiagFunc: validator.StringInSlice(true, "All Severities", "Critical", "High", "Medium", "Low"),
 					},
 					"secrets": {

--- a/pkg/xray/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource_xray_security_policy_test.go
@@ -846,8 +846,7 @@ const securityPolicyVulnIdsConflict = `resource "xray_security_policy" "{{ .reso
 		name = "{{ .rule_name }}"
 		priority = 1
 		criteria {
-			{{ .test_attribute }}			
-//vulnerability_ids = ["{{ .CVE_1 }}", "{{ .CVE_2 }}", "{{ .CVE_3 }}"]
+			{{ .test_attribute }}
 			{{ .conflicting_attribute }}
 		}
 		actions {


### PR DESCRIPTION
Exposures will only work with JAS license. If the license doesn't have JAS extension, exposures section won't be returned in the API call and can cause state drift.
As for today, we can't tell if JAS is enabled based on the license information from the API endpoint and we're adding it to the user's discretion. 