### PR TITLE
Remove attribute conflict validation for 'cves' and 'vulnerabilities'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.4 (November 30, 2023)
+## 2.0.4 (November 30, 2023). Tested on Artifactory 7.71.5 and Xray 3.86.3
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.4 (November 30, 2023)
+
+BUG FIXES:
+
+* resource/xray_ignore_rule: Remove validation against setting attributes `vulnerabilities` and `cves` at the same time. Removed `Computed` attribute for `cves` to avoid state drift and forced replacement. PR: [#151](https://github.com/jfrog/terraform-provider-xray/pull/151) Issue: [#148](https://github.com/jfrog/terraform-provider-xray/issues/148)
+
 ## 2.0.3 (November 17, 2023). Tested on Artifactory 7.71.4 and Xray 3.85.5
 
 BUG FIXES:

--- a/docs/resources/ignore_rule.md
+++ b/docs/resources/ignore_rule.md
@@ -66,7 +66,7 @@ resource "xray_ignore_rule" "ignore-111" {
 - `artifact` (Block Set) List of specific artifacts to ignore. Omit to apply to all. (see [below for nested schema](#nestedblock--artifact))
 - `build` (Block Set) List of specific builds to ignore. Omit to apply to all. (see [below for nested schema](#nestedblock--build))
 - `component` (Block Set) List of specific components to ignore. Omit to apply to all. (see [below for nested schema](#nestedblock--component))
-- `cves` (Set of String) List of specific CVEs to ignore. Omit to apply to all.
+- `cves` (Set of String) List of specific CVEs to ignore. Omit to apply to all. Should set to 'any' when 'vulnerabilities' is set to 'any'.
 - `docker_layers` (Set of String) List of Docker layer SHA256 hashes to ignore. Omit to apply to all.
 - `expiration_date` (String) The Ignore Rule will be active until the expiration date. At that date it will automatically get deleted. The rule with the expiration date less than current day, will error out.
 - `licenses` (Set of String) List of specific licenses to ignore. Omit to apply to all.

--- a/pkg/xray/resource_xray_ignore_rule_test.go
+++ b/pkg/xray/resource_xray_ignore_rule_test.go
@@ -439,6 +439,7 @@ func TestAccIgnoreRule_docker_layers(t *testing.T) {
 		  notes            = "fake notes"
 		  expiration_date  = "{{ .expirationDate }}"
 		  vulnerabilities  = ["any"]
+		  cves             = ["any"]
 
 		  docker_layers = [
 		    "2ae0e4835a9a6e22e35dd0fcce7d7354999476b7dad8698d2d7a77c80bfc647b",
@@ -527,6 +528,7 @@ func sourceTestCase(source string, t *testing.T) (*testing.T, resource.TestCase)
 		  notes            = "fake notes"
 		  expiration_date  = "{{ .expirationDate }}"
 		  vulnerabilities  = ["any"]
+		  cves             = ["any"]
 
 		  {{ .source }} {
 			  name    = "fake-name"
@@ -573,6 +575,7 @@ func TestAccIgnoreRule_artifact(t *testing.T) {
 		  notes            = "fake notes"
 		  expiration_date  = "{{ .expirationDate }}"
 		  vulnerabilities  = ["any"]
+		  cves             = ["any"]
 
 		  artifact {
 			  name    = "fake-name"
@@ -648,36 +651,49 @@ func TestAccIgnoreRule_invalid_artifact_path(t *testing.T) {
 func TestAccIgnoreRule_with_project_key(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("ignore-rule-", "xray_ignore_rule")
 	expirationDate := time.Now().Add(time.Hour * 48)
-	projectKey := fmt.Sprintf("testproj%d", testutil.RandSelect(1, 2, 3, 4, 5))
+	projectKey := fmt.Sprintf("testproj%d", testutil.RandomInt())
 
-	config := sdk.ExecuteTemplate("TestAccIgnoreRule", `
-		resource "xray_ignore_rule" "{{ .name }}" {
-		  notes            = "fake notes"
-		  expiration_date  = "{{ .expirationDate }}"
-		  vulnerabilities  = ["any"]
-		  project_key      = "{{ .projectKey }}"
-
-		  docker_layers = [
-		    "2ae0e4835a9a6e22e35dd0fcce7d7354999476b7dad8698d2d7a77c80bfc647b",
-			"a8db0e25d5916e70023114bb2d2497cd85327486bd6e0dc2092b349a1ab3a0a0"
-		  ]
+	config := sdk.ExecuteTemplate(
+		"TestAccIgnoreRule",
+		`resource "project" "{{ .projectKey }}" {
+			key          = "{{ .projectKey }}"
+			display_name = "{{ .projectKey }}"
+			admin_privileges {
+				manage_members   = true
+				manage_resources = true
+				index_resources  = true
+			}
 		}
-	`, map[string]interface{}{
-		"name":           name,
-		"expirationDate": expirationDate.Format("2006-01-02"),
-		"projectKey":     projectKey,
-	})
+
+		resource "xray_ignore_rule" "{{ .name }}" {
+			notes            = "fake notes"
+			expiration_date  = "{{ .expirationDate }}"
+			vulnerabilities  = ["any"]
+			cves             = ["any"]
+			project_key      = project.{{ .projectKey }}.key
+
+			build {
+				name    = "fake-name"
+				version = "fake-version"
+			}
+		}`,
+		map[string]interface{}{
+			"name":           name,
+			"expirationDate": expirationDate.Format("2006-01-02"),
+			"projectKey":     projectKey,
+		},
+	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			CreateProject(t, projectKey)
-		},
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders(),
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			DeleteProject(t, projectKey)
-			return testCheckIgnoreRule(id, request)
-		}),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"project": {
+				Source:            "registry.terraform.io/jfrog/project",
+				VersionConstraint: "1.3.4",
+			},
+		},
+		CheckDestroy: verifyDeleted(fqrn, testCheckIgnoreRule),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/pkg/xray/resource_xray_ignore_rule_test.go
+++ b/pkg/xray/resource_xray_ignore_rule_test.go
@@ -672,10 +672,10 @@ func TestAccIgnoreRule_with_project_key(t *testing.T) {
 			cves             = ["any"]
 			project_key      = project.{{ .projectKey }}.key
 
-			build {
-				name    = "fake-name"
-				version = "fake-version"
-			}
+			docker_layers = [
+				"2ae0e4835a9a6e22e35dd0fcce7d7354999476b7dad8698d2d7a77c80bfc647b",
+				"a8db0e25d5916e70023114bb2d2497cd85327486bd6e0dc2092b349a1ab3a0a0"
+			]
 		}`,
 		map[string]interface{}{
 			"name":           name,


### PR DESCRIPTION
Also remove 'Computed' attribute for 'cves'. Practitioners need to set "any" if 'vulnerabilities' is also set to 'any' to avoid state drift.

Update documentation for the same.

Closed #148 