### PR TITLE
Fix report resources import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 2.1.1 (January 22, 2024)
+
+IMPROVEMENTS:
+
+* resource/xray_*_report: remove "Import" section from report documentation as these resources do not support importing. PR: [#160](https://github.com/jfrog/terraform-provider-xray/pull/160) Issue: [#157](https://github.com/jfrog/terraform-provider-xray/issues/157)
+
 ## 2.1.0 (December 7, 2023). Tested on Artifactory 7.71.11 and Xray 3.87.5
 
 IMPROVEMENTS:
 
-* resource/xray_watch: add support for watch type `releaseBundle`, `all-releaseBundles`, `releaseBundleV2`, and `all-releaseBundlesV2`. PR: [#153](https://github.com/jfrog/terraform-provider-xray/pull/153) Issue: [#150](https://github.com/jfrog/terraform-provider-xray/issues/159)
+* resource/xray_watch: add support for watch type `releaseBundle`, `all-releaseBundles`, `releaseBundleV2`, and `all-releaseBundlesV2`. PR: [#153](https://github.com/jfrog/terraform-provider-xray/pull/153) Issue: [#150](https://github.com/jfrog/terraform-provider-xray/issues/150)
 
 ## 2.0.5 (November 30, 2023). Tested on Artifactory 7.71.5 and Xray 3.86.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1 (January 22, 2024)
+## 2.1.1 (January 22, 2024). Tested on Artifactory 7.71.11 and Xray 3.87.9
 
 IMPROVEMENTS:
 

--- a/docs/resources/licenses_report.md
+++ b/docs/resources/licenses_report.md
@@ -137,10 +137,3 @@ Optional:
 
 - `exclude_path_patterns` (Set of String) Exclude path patterns.
 - `include_path_patterns` (Set of String) Include path patterns.
-
-## Import
-
-License reports can be imported using their names, e.g.
-```
-$ terraform import xray_licenses_report.test-license-report report
-```

--- a/docs/resources/operational_risks_report.md
+++ b/docs/resources/operational_risks_report.md
@@ -132,10 +132,3 @@ Optional:
 
 - `exclude_path_patterns` (Set of String) Exclude path patterns.
 - `include_path_patterns` (Set of String) Include path patterns.
-
-## Import
-
-Operational risk reports can be imported using their names, e.g.
-```
-$ terraform import xray_operational_risks_report.report test-operational-risks-report
-```

--- a/docs/resources/violations_report.md
+++ b/docs/resources/violations_report.md
@@ -191,10 +191,3 @@ Optional:
 
 - `exclude_path_patterns` (Set of String) Exclude path patterns.
 - `include_path_patterns` (Set of String) Include path patterns.
-
-## Import
-
-Violations reports can be imported using their names, e.g.
-```
-$ terraform import xray_violations_report.report test-violations-report 
-```

--- a/docs/resources/vulnerabilities_report.md
+++ b/docs/resources/vulnerabilities_report.md
@@ -166,10 +166,3 @@ Optional:
 
 - `exclude_path_patterns` (Set of String) Exclude path patterns.
 - `include_path_patterns` (Set of String) Include path patterns.
-
-## Import
-
-Vulnerabilities reports can be imported using their names, e.g.
-```
-$ terraform import xray_vulnerabilities_report.report test-vulnerabilities-report
-```

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/jfrog/terraform-provider-shared v1.21.1
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
-	golang.org/x/text v0.14.0
 )
 
 require (
@@ -70,6 +69,7 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	google.golang.org/grpc v1.57.1 // indirect

--- a/pkg/xray/reports.go
+++ b/pkg/xray/reports.go
@@ -312,16 +312,6 @@ func unpackReport(d *schema.ResourceData, reportType string) *Report {
 	return &report
 }
 
-func unpackReportProjectKey(d *schema.ResourceData) *Report {
-	report := Report{}
-
-	if v, ok := d.GetOk("project_key"); ok {
-		report.ProjectKey = v.(string)
-	}
-
-	return &report
-}
-
 func unpackResources(configured *schema.Set) *Resources {
 	var resources Resources
 	m := configured.List()[0].(map[string]interface{})
@@ -606,22 +596,18 @@ func unpackStartAndEndDate(d *schema.Set) *StartAndEndDate {
 }
 
 func resourceXrayVulnerabilitiesReportCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-
 	return createReport("vulnerabilities", d, m)
 }
 
 func resourceXrayLicensesReportCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-
 	return createReport("licenses", d, m)
 }
 
 func resourceXrayViolationsReportCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-
 	return createReport("violations", d, m)
 }
 
 func resourceXrayOperationalRisksReportCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-
 	return createReport("operationalRisks", d, m)
 }
 
@@ -657,9 +643,7 @@ func resourceXrayReportDelete(_ context.Context, d *schema.ResourceData, m inter
 	}
 
 	resp, err := req.
-		SetPathParams(map[string]string{
-			"reportId": d.Id(),
-		}).
+		SetPathParam("reportId", d.Id()).
 		Delete("xray/api/v1/reports/{reportId}")
 	if err != nil && resp.StatusCode() == http.StatusNotFound {
 		d.SetId("")
@@ -813,7 +797,6 @@ func reportResourceDiff(_ context.Context, diff *schema.ResourceDiff, v interfac
 				}
 			}
 		}
-
 	}
 	return nil
 }

--- a/pkg/xray/resource_xray_report_test.go
+++ b/pkg/xray/resource_xray_report_test.go
@@ -3,7 +3,6 @@ package xray
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -11,8 +10,6 @@ import (
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-shared/util/sdk"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 var licenseFilterFields = map[string]interface{}{
@@ -276,8 +273,7 @@ func TestAccReport_Licenses(t *testing.T) {
 
 	for _, reportResource := range resourcesList {
 		resourceNameInReport := reportResource["name"].(string)
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-		t.Run(title, func(t *testing.T) {
+		t.Run(resourceNameInReport, func(t *testing.T) {
 			resource.Test(mkFilterTestCase(t, reportResource, licenseFilterFields, terraformReportName,
 				terraformResourceName))
 		})
@@ -290,8 +286,7 @@ func TestAccReport_OperationalRisks(t *testing.T) {
 
 	for _, reportResource := range resourcesList {
 		resourceNameInReport := reportResource["name"].(string)
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-		t.Run(title, func(t *testing.T) {
+		t.Run(resourceNameInReport, func(t *testing.T) {
 			resource.Test(mkFilterTestCase(t, reportResource, opRisksFilterFields, terraformReportName,
 				terraformResourceName))
 		})
@@ -304,8 +299,7 @@ func TestAccReport_Violations(t *testing.T) {
 
 	for _, reportResource := range resourcesList {
 		resourceNameInReport := reportResource["name"].(string)
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-		t.Run(title, func(t *testing.T) {
+		t.Run(resourceNameInReport, func(t *testing.T) {
 			resource.Test(mkFilterTestCase(t, reportResource, violationsFilterFields[0], terraformReportName,
 				terraformResourceName))
 		})
@@ -317,8 +311,7 @@ func TestAccViolationsReportFilters(t *testing.T) {
 	terraformResourceName := "xray_violations_report"
 
 	for _, violationsFilter := range violationsFilterFields {
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower("various_violations_filters"))
-		t.Run(title, func(t *testing.T) {
+		t.Run("various_violations_filters", func(t *testing.T) {
 			resource.Test(mkFilterTestCase(t, resourcesList[0], violationsFilter, terraformReportName,
 				terraformResourceName))
 		})
@@ -331,8 +324,7 @@ func TestAccReport_Vulnerabilities(t *testing.T) {
 
 	for _, reportResource := range resourcesList {
 		resourceNameInReport := reportResource["name"].(string)
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-		t.Run(title, func(t *testing.T) {
+		t.Run(resourceNameInReport, func(t *testing.T) {
 			resource.Test(mkFilterTestCase(t, reportResource, vulnerabilitiesFilterFields, terraformReportName,
 				terraformResourceName))
 		})
@@ -346,8 +338,7 @@ func TestAccReport_BadResource(t *testing.T) {
 
 	for _, reportResource := range resourcesListNegative {
 		resourceNameInReport := reportResource["name"].(string)
-		title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-		t.Run(title, func(t *testing.T) {
+		t.Run(resourceNameInReport, func(t *testing.T) {
 			resource.Test(mkFilterNegativeTestCase(t, reportResource, licenseFilterFields, terraformReportName,
 				terraformResourceName, expectedErrorMessage))
 		})
@@ -375,8 +366,7 @@ func TestAccReport_BadLicenseFilter(t *testing.T) {
 	}
 
 	resourceNameInReport := resourcesList[0]["name"].(string)
-	title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-	t.Run(title, func(t *testing.T) {
+	t.Run(resourceNameInReport, func(t *testing.T) {
 		resource.Test(mkFilterNegativeTestCase(t, resourcesList[0], filterFieldsConflict, terraformReportName,
 			terraformResourceName, expectedErrorMessage))
 	})
@@ -421,8 +411,7 @@ func TestAccReport_BadViolationsFilter(t *testing.T) {
 	}
 
 	resourceNameInReport := resourcesList[0]["name"].(string)
-	title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-	t.Run(title, func(t *testing.T) {
+	t.Run(resourceNameInReport, func(t *testing.T) {
 		resource.Test(mkFilterNegativeTestCase(t, resourcesList[0], filterFieldsConflict, terraformReportName,
 			terraformResourceName, expectedErrorMessage))
 	})
@@ -457,8 +446,7 @@ func TestAccReport_BadVulnerabilitiesFilter(t *testing.T) {
 	}
 
 	resourceNameInReport := resourcesList[0]["name"].(string)
-	title := cases.Title(language.AmericanEnglish).String(strings.ToLower(resourceNameInReport))
-	t.Run(title, func(t *testing.T) {
+	t.Run(resourceNameInReport, func(t *testing.T) {
 		resource.Test(mkFilterNegativeTestCase(t, resourcesList[0], filterFieldsConflict, terraformReportName,
 			terraformResourceName, expectedErrorMessage))
 	})

--- a/templates/resources/licenses_report.md.tmpl
+++ b/templates/resources/licenses_report.md.tmpl
@@ -13,10 +13,3 @@ Creates Xray License Due Diligence report. The License Due Diligence report prov
 {{tffile "examples/resources/xray_licenses_report/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
-
-## Import
-
-License reports can be imported using their names, e.g.
-```
-$ terraform import xray_licenses_report.test-license-report report
-```

--- a/templates/resources/operational_risks_report.md.tmpl
+++ b/templates/resources/operational_risks_report.md.tmpl
@@ -13,10 +13,3 @@ Creates Xray Operational Risks report. The Operational Risk report provides you 
 {{tffile "examples/resources/xray_operational_risks_report/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
-
-## Import
-
-Operational risk reports can be imported using their names, e.g.
-```
-$ terraform import xray_operational_risks_report.report test-operational-risks-report
-```

--- a/templates/resources/violations_report.md.tmpl
+++ b/templates/resources/violations_report.md.tmpl
@@ -13,10 +13,3 @@ Creates Xray Violations report. The Violations report provides you with informat
 {{tffile "examples/resources/xray_violations_report/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
-
-## Import
-
-Violations reports can be imported using their names, e.g.
-```
-$ terraform import xray_violations_report.report test-violations-report 
-```

--- a/templates/resources/vulnerabilities_report.md.tmpl
+++ b/templates/resources/vulnerabilities_report.md.tmpl
@@ -13,10 +13,3 @@ Creates Xray Vulnerabilities report. The Vulnerabilities report provides informa
 {{tffile "examples/resources/xray_vulnerabilities_report/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
-
-## Import
-
-Vulnerabilities reports can be imported using their names, e.g.
-```
-$ terraform import xray_vulnerabilities_report.report test-vulnerabilities-report
-```


### PR DESCRIPTION
closes #157 

* Remove "Import" section from report resource documentation as import is not supported.
* Remove the need to transform the sub test names