### PR TITLE
parse time in local tz

### DIFF
--- a/docs/resources/ignore_rule.md
+++ b/docs/resources/ignore_rule.md
@@ -68,7 +68,7 @@ resource "xray_ignore_rule" "ignore-111" {
 - `component` (Block Set) List of specific components to ignore. Omit to apply to all. (see [below for nested schema](#nestedblock--component))
 - `cves` (Set of String) List of specific CVEs to ignore. Omit to apply to all. Should set to 'any' when 'vulnerabilities' is set to 'any'.
 - `docker_layers` (Set of String) List of Docker layer SHA256 hashes to ignore. Omit to apply to all.
-- `expiration_date` (String) The Ignore Rule will be active until the expiration date. At that date it will automatically get deleted. The rule with the expiration date less than current day, will error out.
+- `expiration_date` (String) The Ignore Rule will be active until the expiration date. At that date it will automatically get deleted. The rule with the expiration date less than current day, will error out. Ensure client and server time zones match.
 - `licenses` (Set of String) List of specific licenses to ignore. Omit to apply to all.
 - `operational_risk` (Set of String) Operational risk to ignore. Only accept 'any'
 - `policies` (Set of String) List of specific policies to ignore. Omit to apply to all.

--- a/pkg/xray/resource/resource_xray_ignore_rule.go
+++ b/pkg/xray/resource/resource_xray_ignore_rule.go
@@ -114,7 +114,7 @@ func (m IgnoreRuleResourceModel) toAPIModel(ctx context.Context, apiModel *Ignor
 
 	var expiresAt *time.Time
 	if m.ExpiredAt.ValueString() != "" {
-		parsedTime, err := time.Parse("2006-01-02", m.ExpiredAt.ValueString())
+		parsedTime, err := time.ParseInLocation("2006-01-02", m.ExpiredAt.ValueString(), time.Local)
 		if err != nil {
 			ds.AddError(
 				"failed to parse date/time string",


### PR DESCRIPTION
resolve #237 

Test env ( on alpine)

Set tz to EST
```
$ date
XXX UTC 2024

$ apk tzdata
$ ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime

$ date
XXX EDT 2024
```
- opentofu 1.8.2 (ghcr.io/opentofu/opentofu)
- terraform 1.9.5 ( docker.io/hashicorp/terraform)


What is tested
- client and server have same tz
- server and client have different tz ( client tz is mapped to server tz )

Actual results:
Without this tz is parsed in UTC regardless of local tz

Expected result
tz should parsed in local tz, or provide the option to specify time with tz ( 2024-11-01T13:00-04:00/ 2024-11-01T13:00Z/...)
