### PR TITLE
Fix time parsing for 'expiration_date' from API payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.13.1 (October 31, 2024)
+
+BUG FIXES:
+
+* resource/xray_ignore_rule: Fix another date parsing issue with timezone for `expiration_date` attribute. Issue: [#259](https://github.com/jfrog/terraform-provider-xray/issues/259) PR: [#260](https://github.com/jfrog/terraform-provider-xray/issues/260)
+
 ## 2.13.0 (October 17, 2024). Tested on Artifactory 7.90.14 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.13.1 (October 31, 2024)
+## 2.13.1 (October 31, 2024). Tested on Artifactory 7.98.7 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.4
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_xray_ignore_rule.go
+++ b/pkg/xray/resource/resource_xray_ignore_rule.go
@@ -348,7 +348,7 @@ func (m *IgnoreRuleResourceModel) fromAPIModel(ctx context.Context, apiModel Ign
 
 	expiresAt := types.StringNull()
 	if apiModel.ExpiresAt != nil {
-		expiresAt = types.StringValue(apiModel.ExpiresAt.Format("2006-01-02"))
+		expiresAt = types.StringValue(apiModel.ExpiresAt.Local().Format("2006-01-02"))
 	}
 	m.ExpiredAt = expiresAt
 

--- a/pkg/xray/resource/resource_xray_ignore_rule_test.go
+++ b/pkg/xray/resource/resource_xray_ignore_rule_test.go
@@ -607,7 +607,7 @@ func sourceTestCase(source string, t *testing.T) (*testing.T, resource.TestCase)
 
 func TestAccIgnoreRule_artifact(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("ignore-rule-", "xray_ignore_rule")
-	expirationDate := time.Now().Add(time.Hour * 48)
+	expirationDate := time.Now().UTC().Add(time.Hour * 48)
 
 	config := util.ExecuteTemplate("TestAccIgnoreRule", `
 		resource "xray_ignore_rule" "{{ .name }}" {
@@ -624,7 +624,7 @@ func TestAccIgnoreRule_artifact(t *testing.T) {
 		}
 	`, map[string]interface{}{
 		"name":           name,
-		"expirationDate": expirationDate.Format("2006-01-02"),
+		"expirationDate": expirationDate.Local().Format("2006-01-02"),
 	})
 
 	resource.Test(t, resource.TestCase{
@@ -636,7 +636,7 @@ func TestAccIgnoreRule_artifact(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(fqrn, "id"),
 					resource.TestCheckResourceAttr(fqrn, "notes", "fake notes"),
-					resource.TestCheckResourceAttr(fqrn, "expiration_date", expirationDate.Format("2006-01-02")),
+					resource.TestCheckResourceAttr(fqrn, "expiration_date", expirationDate.Local().Format("2006-01-02")),
 					resource.TestCheckResourceAttr(fqrn, "is_expired", "false"),
 					resource.TestCheckResourceAttr(fqrn, "artifact.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "artifact.0.name", "fake-name"),


### PR DESCRIPTION
Potentially fixes #259 