### PR TITLE
Fix unknown value error when creating new security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-## 2.13.1 (October 31, 2024). Tested on Artifactory 7.98.8 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.5
+## 2.13.2 (November 8, 2024)
 
 BUG FIXES:
 
-* resource/xray_ignore_rule: Fix another date parsing issue with timezone for `expiration_date` attribute. Issue: [#265](https://github.com/jfrog/terraform-provider-xray/issues/265) PR: [#268](https://github.com/jfrog/terraform-provider-xray/issues/268)
+* resource/xray_security_policy: Fix "Provider produced inconsistent result after apply" error after resource creation. Issue: [#265](https://github.com/jfrog/terraform-provider-xray/issues/265) PR: [#268](https://github.com/jfrog/terraform-provider-xray/issues/268)
+
+
+## 2.13.1 (October 31, 2024). Tested on Artifactory 7.98.7 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.4
+
+BUG FIXES:
+
+* resource/xray_ignore_rule: Fix another date parsing issue with timezone for `expiration_date` attribute. Issue: [#259](https://github.com/jfrog/terraform-provider-xray/issues/259) PR: [#260](https://github.com/jfrog/terraform-provider-xray/issues/260)
 
 ## 2.13.0 (October 17, 2024). Tested on Artifactory 7.90.14 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/xray_ignore_rule: Fix another date parsing issue with timezone for `expiration_date` attribute. Issue: [#259](https://github.com/jfrog/terraform-provider-xray/issues/259) PR: [#260](https://github.com/jfrog/terraform-provider-xray/issues/260)
+* resource/xray_ignore_rule: Fix another date parsing issue with timezone for `expiration_date` attribute. Issue: [#265](https://github.com/jfrog/terraform-provider-xray/issues/265) PR: [#268](https://github.com/jfrog/terraform-provider-xray/issues/268)
 
 ## 2.13.0 (October 17, 2024). Tested on Artifactory 7.90.14 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.13.2 (November 8, 2024)
+## 2.13.2 (November 8, 2024). Tested on Artifactory 7.98.8 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.5
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.13.1 (October 31, 2024). Tested on Artifactory 7.98.7 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.4
+## 2.13.1 (October 31, 2024). Tested on Artifactory 7.98.8 and Xray 3.104.18 with Terraform 1.9.8 and OpenTofu 1.8.5
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_xray_license_policy.go
+++ b/pkg/xray/resource/resource_xray_license_policy.go
@@ -197,7 +197,7 @@ func (m *LicensePolicyResource) fromActionsAPIModel(ctx context.Context, actions
 			"notify_deployer":                    types.BoolValue(actionsAPIModel.NotifyDeployer),
 			"notify_watch_recipients":            types.BoolValue(actionsAPIModel.NotifyWatchRecipients),
 			"create_ticket_enabled":              types.BoolValue(actionsAPIModel.CreateJiraTicketEnabled),
-			"build_failure_grace_period_in_days": types.Int64PointerValue(actionsAPIModel.FailureGracePeriodDays),
+			"build_failure_grace_period_in_days": types.Int64Value(actionsAPIModel.FailureGracePeriodDays),
 			"custom_severity":                    types.StringValue(actionsAPIModel.CustomSeverity),
 		},
 	)

--- a/pkg/xray/resource/resource_xray_security_policy.go
+++ b/pkg/xray/resource/resource_xray_security_policy.go
@@ -87,9 +87,9 @@ func (r *SecurityPolicyResource) toCriteriaAPIModel(ctx context.Context, criteri
 		criteria = &PolicyRuleCriteriaAPIModel{
 			MinimumSeverity:     attrs["min_severity"].(types.String).ValueString(),
 			CVSSRange:           cvssRange,
-			FixVersionDependant: attrs["fix_version_dependant"].(types.Bool).ValueBool(),
-			ApplicableCVEsOnly:  attrs["applicable_cves_only"].(types.Bool).ValueBool(),
-			MaliciousPackage:    attrs["malicious_package"].(types.Bool).ValueBool(),
+			FixVersionDependant: attrs["fix_version_dependant"].(types.Bool).ValueBoolPointer(),
+			ApplicableCVEsOnly:  attrs["applicable_cves_only"].(types.Bool).ValueBoolPointer(),
+			MaliciousPackage:    attrs["malicious_package"].(types.Bool).ValueBoolPointer(),
 			VulnerabilityIds:    vulnerabilityIds,
 			Exposures:           exposures,
 			PackageName:         attrs["package_name"].(types.String).ValueString(),
@@ -105,23 +105,23 @@ func (r SecurityPolicyResource) toAPIModel(ctx context.Context, plan PolicyResou
 	return plan.toAPIModel(ctx, policy, r.toCriteriaAPIModel, toActionsAPIModel)
 }
 
-func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, criteraAPIModel *PolicyRuleCriteriaAPIModel) (types.Set, diag.Diagnostics) {
+func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, criteriaAPIModel *PolicyRuleCriteriaAPIModel) (types.Set, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	criteriaSet := types.SetNull(securityCriteriaSetElementType)
-	if criteraAPIModel != nil {
+	if criteriaAPIModel != nil {
 		minimumSeverity := types.StringNull()
-		if criteraAPIModel.MinimumSeverity != "" {
-			minimumSeverity = types.StringValue(criteraAPIModel.MinimumSeverity)
+		if criteriaAPIModel.MinimumSeverity != "" {
+			minimumSeverity = types.StringValue(criteriaAPIModel.MinimumSeverity)
 		}
 
 		cvssRangeList := types.ListNull(cvssRangeElementType)
-		if criteraAPIModel.CVSSRange != nil {
+		if criteriaAPIModel.CVSSRange != nil {
 			cvssRange, d := types.ObjectValue(
 				cvssRangeAttrType,
 				map[string]attr.Value{
-					"from": types.Float64PointerValue(criteraAPIModel.CVSSRange.From),
-					"to":   types.Float64PointerValue(criteraAPIModel.CVSSRange.To),
+					"from": types.Float64PointerValue(criteriaAPIModel.CVSSRange.From),
+					"to":   types.Float64PointerValue(criteriaAPIModel.CVSSRange.To),
 				},
 			)
 			if d.HasError() {
@@ -139,16 +139,16 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 			cvssRangeList = cr
 		}
 
-		vulnerabilityIDs, d := types.SetValueFrom(ctx, types.StringType, criteraAPIModel.VulnerabilityIds)
+		vulnerabilityIDs, d := types.SetValueFrom(ctx, types.StringType, criteriaAPIModel.VulnerabilityIds)
 		if d.HasError() {
 			diags.Append(d...)
 		}
 
 		exposuresList := types.ListNull(exposuresElementType)
-		if criteraAPIModel.Exposures != nil {
+		if criteriaAPIModel.Exposures != nil {
 			var minSeverity *string
-			if criteraAPIModel.Exposures.MinSeverity != nil {
-				s := lo.Capitalize(*criteraAPIModel.Exposures.MinSeverity)
+			if criteriaAPIModel.Exposures.MinSeverity != nil {
+				s := lo.Capitalize(*criteriaAPIModel.Exposures.MinSeverity)
 				minSeverity = &s
 			}
 
@@ -156,10 +156,10 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 				exposuresAttrType,
 				map[string]attr.Value{
 					"min_severity": types.StringPointerValue(minSeverity),
-					"secrets":      types.BoolPointerValue(criteraAPIModel.Exposures.Secrets),
-					"applications": types.BoolPointerValue(criteraAPIModel.Exposures.Applications),
-					"services":     types.BoolPointerValue(criteraAPIModel.Exposures.Services),
-					"iac":          types.BoolPointerValue(criteraAPIModel.Exposures.Iac),
+					"secrets":      types.BoolPointerValue(criteriaAPIModel.Exposures.Secrets),
+					"applications": types.BoolPointerValue(criteriaAPIModel.Exposures.Applications),
+					"services":     types.BoolPointerValue(criteriaAPIModel.Exposures.Services),
+					"iac":          types.BoolPointerValue(criteriaAPIModel.Exposures.Iac),
 				},
 			)
 			if d.HasError() {
@@ -178,16 +178,16 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 		}
 
 		packageName := types.StringNull()
-		if criteraAPIModel.PackageName != "" {
-			packageName = types.StringValue(criteraAPIModel.PackageName)
+		if criteriaAPIModel.PackageName != "" {
+			packageName = types.StringValue(criteriaAPIModel.PackageName)
 		}
 
 		packageType := types.StringNull()
-		if criteraAPIModel.PackageType != "" {
-			packageType = types.StringValue(criteraAPIModel.PackageType)
+		if criteriaAPIModel.PackageType != "" {
+			packageType = types.StringValue(criteriaAPIModel.PackageType)
 		}
 
-		packageVersions, d := types.SetValueFrom(ctx, types.StringType, criteraAPIModel.PackageVersions)
+		packageVersions, d := types.SetValueFrom(ctx, types.StringType, criteriaAPIModel.PackageVersions)
 		if d.HasError() {
 			diags.Append(d...)
 		}
@@ -196,9 +196,9 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 			securityCriteriaAttrTypes,
 			map[string]attr.Value{
 				"min_severity":          minimumSeverity,
-				"fix_version_dependant": types.BoolValue(criteraAPIModel.FixVersionDependant),
-				"applicable_cves_only":  types.BoolValue(criteraAPIModel.ApplicableCVEsOnly),
-				"malicious_package":     types.BoolValue(criteraAPIModel.MaliciousPackage),
+				"fix_version_dependant": types.BoolPointerValue(criteriaAPIModel.FixVersionDependant),
+				"applicable_cves_only":  types.BoolPointerValue(criteriaAPIModel.ApplicableCVEsOnly),
+				"malicious_package":     types.BoolPointerValue(criteriaAPIModel.MaliciousPackage),
 				"cvss_range":            cvssRangeList,
 				"vulnerability_ids":     vulnerabilityIDs,
 				"exposures":             exposuresList,
@@ -381,20 +381,14 @@ var securityPolicyCriteriaAttrs = map[string]schema.Attribute{
 	},
 	"fix_version_dependant": schema.BoolAttribute{
 		Optional:    true,
-		Computed:    true,
-		Default:     booldefault.StaticBool(false),
-		Description: "Default value is `false`. Issues that do not have a fixed version are not generated until a fixed version is available. Must be `false` with `malicious_package` enabled.",
+		Description: "Issues that do not have a fixed version are not generated until a fixed version is available. Must be `false` with `malicious_package` enabled.",
 	},
 	"applicable_cves_only": schema.BoolAttribute{
 		Optional:    true,
-		Computed:    true,
-		Default:     booldefault.StaticBool(false),
-		Description: "Default value is `false`. Mark to skip CVEs that are not applicable in the context of the artifact. The contextual analysis operation might be long and affect build time if the `fail_build` action is set.\n\n~>Only supported by JFrog Advanced Security",
+		Description: "Mark to skip CVEs that are not applicable in the context of the artifact. The contextual analysis operation might be long and affect build time if the `fail_build` action is set.\n\n~>Only supported by JFrog Advanced Security",
 	},
 	"malicious_package": schema.BoolAttribute{
 		Optional: true,
-		Computed: true,
-		Default:  booldefault.StaticBool(false),
 		Validators: []validator.Bool{
 			boolvalidator.ConflictsWith(
 				path.MatchRelative().AtParent().AtName("min_severity"),
@@ -403,7 +397,7 @@ var securityPolicyCriteriaAttrs = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("cvss_range"),
 			),
 		},
-		Description: "Default value is `false`. Generating a violation on a malicious package.",
+		Description: "Generating a violation on a malicious package.",
 	},
 	"vulnerability_ids": schema.SetAttribute{
 		ElementType: types.StringType,

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -1207,10 +1207,7 @@ const securityPolicyTwoRules = `resource "xray_security_policy" "{{ .resource_na
 		name = "{{ .rule_name_1 }}"
 		priority = 1
 		criteria {
-			cvss_range {
-				from = {{ .cvss_from }}
-				to = {{ .cvss_to }}
-			}
+			min_severity = "{{ .min_severity }}"
 		}
 		actions {
 			block_release_bundle_distribution = {{ .block_release_bundle_distribution }}

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -27,9 +27,8 @@ var testDataSecurity = map[string]string{
 	"policy_name":                       "terraform-security-policy",
 	"policy_description":                "policy created by xray acceptance tests",
 	"rule_name":                         "test-security-rule",
-	"cvss_from":                         "1", // conflicts with min_severity
-	"cvss_to":                           "5", // conflicts with min_severity
-	"applicable_cves_only":              fmt.Sprintf("%t", testutil.RandBool()),
+	"cvss_from":                         "1",    // conflicts with min_severity
+	"cvss_to":                           "5",    // conflicts with min_severity
 	"min_severity":                      "High", // conflicts with cvss_from/cvss_to
 	"block_release_bundle_distribution": "true",
 	"block_release_bundle_promotion":    "true",
@@ -50,7 +49,6 @@ func TestAccSecurityPolicy_UpgradeFromSDKv2(t *testing.T) {
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-4-%d", testutil.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-4-%d", testutil.RandomInt())
-	testData["applicable_cves_only"] = "false"
 
 	template := `
 	resource "xray_security_policy" "{{ .resource_name }}" {
@@ -329,7 +327,6 @@ func TestAccSecurityPolicy_withProjectKey(t *testing.T) {
 	testData["project_key"] = projectKey
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-4-%d", testutil.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-4-%d", testutil.RandomInt())
-	testData["applicable_cves_only"] = "false"
 
 	template := `
 	resource "project" "{{ .project_key }}" {
@@ -417,7 +414,6 @@ func TestAccSecurityPolicy_createBlockDownloadTrueCVSS(t *testing.T) {
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-4-%d", testutil.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-4-%d", testutil.RandomInt())
-	testData["applicable_cves_only"] = "false"
 
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
@@ -445,7 +441,6 @@ func TestAccSecurityPolicy_createBlockDownloadFalseCVSS(t *testing.T) {
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-5-%d", testutil.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-5-%d", testutil.RandomInt())
-	testData["applicable_cves_only"] = "false"
 	testData["block_unscanned"] = "false"
 	testData["block_active"] = "false"
 
@@ -652,7 +647,6 @@ func TestAccSecurityPolicy_createCVSSFloat(t *testing.T) {
 	testData["resource_name"] = resourceName
 	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-8-%d", testutil.RandomInt())
 	testData["rule_name"] = fmt.Sprintf("test-security-rule-8-%d", testutil.RandomInt())
-	testData["applicable_cves_only"] = "false"
 	testData["cvss_from"] = "1.5"
 	testData["cvss_to"] = "5.3"
 
@@ -1036,12 +1030,12 @@ func verifySecurityPolicy(fqrn string, testData map[string]string, criteriaType 
 		resource.TestCheckResourceAttr(fqrn, "rule.0.actions.0.block_download.0.active", testData["block_active"]),
 		resource.TestCheckResourceAttr(fqrn, "rule.0.actions.0.block_download.0.unscanned", testData["block_unscanned"]),
 	)
+
 	if criteriaType == criteriaTypeCvss {
 		return resource.ComposeTestCheckFunc(
 			commonCheckList,
 			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.cvss_range.0.from", testData["cvss_from"]),
 			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.cvss_range.0.to", testData["cvss_to"]),
-			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.applicable_cves_only", testData["applicable_cves_only"]),
 		)
 	}
 	if criteriaType == criteriaTypeSeverity {


### PR DESCRIPTION
By switch API fields to boolean pointers so when they are missing from response payload, the values won't be translated into 'false'.

Also not reusing variables in create/update API as that keep the previous values and thus contain incorrect data.

Fix typo in criteria variable name

Fixes #265 