### PR TITLE
Enhanced ARM64 Build Process with Dynamic GOARM64 Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.7 (June 16, 2025). Tested on Artifactory 7.111.8 with Terraform 1.12.0 and OpenTofu 1.9.1
+
+IMPROVEMENTS:
+
+* GNUmakefile : Enhanced ARM64 Build Process with Dynamic GOARM64 Detection. PR: [332](https://github.com/jfrog/terraform-provider-xray/pull/332)
+
 ## 3.0.6 (April 11, 2025). Tested on Artifactory 7.104.15 and Xray 3.111.24 with Terraform 1.11.4 and OpenTofu 1.9.0
 
 IMPROVEMENTS: 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,11 @@ GORELEASER_ARCH=${TARGET_ARCH}
 ifeq ($(GO_ARCH), amd64)
 GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
 endif
+
+ifeq ($(GO_ARCH), arm64)
+GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOARM64)
+endif
+
 PKG_NAME=pkg/xray
 # if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
 PKG_VERSION_PATH=github.com/jfrog/terraform-provider-${PRODUCT}/${PKG_NAME}


### PR DESCRIPTION
**Problem**:
Previously, building the `terraform-provider-xray` locally on `darwin_arm64` failed due to a path regex mismatch during the `make install` step. The goreleaser build output was not consistently tagged with the precise ARM64 variant, leading to incorrect binary paths and subsequent `mv` errors.

**Exact Error Encountered**:
```
> make install
rm -fR dist terraform.d/ .terraform terraform.tfstate* .terraform.lock.hcl
==> Fixing source code with gofmt...
go: downloading github.com/hashicorp/terraform-plugin-go v0.26.0
go: downloading github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
go: downloading github.com/samber/lo v1.49.1
go: downloading golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
go: downloading golang.org/x/net v0.37.0
go: downloading golang.org/x/text v0.23.0
go: downloading github.com/hashicorp/go-plugin v1.6.2
go: downloading google.golang.org/grpc v1.69.4
go: downloading golang.org/x/sys v0.31.0
go: downloading github.com/hashicorp/terraform-registry-address v0.2.4
go: downloading google.golang.org/protobuf v1.36.3
go: downloading golang.org/x/crypto v0.36.0
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53
GORELEASER_CURRENT_TAG=3.0.7 goreleaser build --single-target --clean --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • couldn't find any tags before "3.0.7"
    • git state                                      commit=07c3ec9faca47b5425800643b01e0ef11440ad2c branch=main current_tag=3.0.7 previous_tag=<unknown> dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • partial
  • snapshotting
    • building snapshot...                           version=3.0.7-SNAPSHOT-07c3ec9f
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=darwin_arm64_v8.0
    • building                                       binary=dist/terraform-provider-xray_darwin_arm64_v8.0/terraform-provider-xray_v3.0.7-SNAPSHOT-07c3ec9f
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • build succeeded after 5s
  • thanks for using GoReleaser!
mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/xray/3.0.7/darwin_arm64 && \
		mv -v dist/terraform-provider-xray_darwin_arm64/terraform-provider-xray_v3.0.7* terraform.d/plugins/registry.terraform.io/jfrog/xray/3.0.7/darwin_arm64 && \
		rm -f .terraform.lock.hcl && \
		sed -i.bak 's/version = ".*"/version = "3.0.7"/' sample.tf && rm sample.tf.bak && \
		terraform init
mv: rename dist/terraform-provider-xray_darwin_arm64/terraform-provider-xray_v3.0.7* to terraform.d/plugins/registry.terraform.io/jfrog/xray/3.0.7/darwin_arm64/terraform-provider-xray_v3.0.7*: No such file or directory
make: *** [install] Error 1
```
**Solution**:
This PR enhances the `GNUmakefile` to dynamically determine the exact ARM64 variant by leveraging `go env GOARM64`. This ensures that `goreleaser` builds are accurately tagged and optimized for different ARM64 environments, resolving the path mismatch issue.
