### PR TITLE
provider config: warn instead of error if xray version can't be obtained

### DIFF
--- a/pkg/xray/provider.go
+++ b/pkg/xray/provider.go
@@ -159,7 +159,7 @@ func (p *XrayProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	version, err := util.GetXrayVersion(restyClient)
 	if err != nil {
-		resp.Diagnostics.AddError(
+		resp.Diagnostics.AddWarning(
 			"Error getting Xray version",
 			err.Error(),
 		)


### PR DESCRIPTION
provider config: warn instead of error if xray version can't be obtained

**Alternative solution:** 
Add a new option to the provider configuration schema e.g. `xray_version_check: bool` with true being the default behaviour. A long time ago, Artifactory Terraform provider had the similar `check_licence` option in the configuration schema

Closes: https://github.com/jfrog/terraform-provider-xray/issues/338