### PR TITLE
Relax the package_versions validation regex to match the Xray API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.9 (April 07, 2026).
+## 3.1.9 (April 07, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.17, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.9 (April 07, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.17, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
+## 3.1.9 (April 07, 2026).
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ BUG FIXES:
 
 * resource/xray_security_policy: Fix state drift for `criteria.exposures.min_severity` when set to `All severities` caused by casing mismatch between Xray API response and provider validator. PR: [#406](https://github.com/jfrog/terraform-provider-xray/pull/406)
 
+* resource/xray_security_policy: Relax `package_versions` validation so hyphenated and other Xray-supported version strings match the API. Issue: [#402](https://github.com/jfrog/terraform-provider-xray/issues/402) PR: [#405](https://github.com/jfrog/terraform-provider-xray/pull/405)
+
 ## 3.1.8 (April 01, 2026). Tested on JFrog Platform 11.4.5 (Artifactory 7.133.15, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
 
 BUG FIXES:

--- a/pkg/xray/resource/resource_xray_security_policy.go
+++ b/pkg/xray/resource/resource_xray_security_policy.go
@@ -462,10 +462,10 @@ var securityPolicyCriteriaAttrs = map[string]schema.Attribute{
 		Optional:    true,
 		Validators: []validator.List{
 			listvalidator.ValueStringsAre(
-				stringvalidator.RegexMatches(regexp.MustCompile(`((^(\(|\[)((\d+\.)?(\d+\.)?(\*|\d+)|(\s*))\,((\d+\.)?(\d+\.)?(\*|\d+)|(\s*))(\)|\])$|^\[(\d+\.)?(\d+\.)?(\*|\d+)\]$))`), "invalid Range, must be one of the follows: Any Version: (,) or Specific Version: [1.2], [3] or Range: (1,), [,1.2.3], (4.5.0,6.5.2]"),
+				stringvalidator.RegexMatches(regexp.MustCompile(`(^(\(|\[)((\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)|(\s*))\,((\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)|(\s*))(\)|\])$|^\[(\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)\]$|^[\dA-Za-z][\dA-Za-z.\-]*$)`), "invalid Range, must be one of the follows: Any Version: (,) or Specific Version: [1.2], [3], a bare version (e.g. 2026.3.31-2), or Range: (1,), [,1.2.3], (4.5.0,6.5.2]"),
 			),
 		},
-		Description: "package versions to apply the rule on can be (,) for any version or an open range (1,4) or closed [1,4] or one version [1]",
+		Description: "package versions to apply the rule on can be (,) for any version or an open range (1,4) or closed [1,4], one version in brackets, or a bare version string",
 	},
 }
 

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -1070,18 +1070,87 @@ func TestAccSecurityPolicy_Packages(t *testing.T) {
 	})
 }
 
+// TestAccSecurityPolicy_PackageVersionsHyphenated validates rule.criteria.package_versions regexp (must match resource_xray_security_policy.go)
+// and end-to-end create/import for hyphenated and related Xray API forms.
+func TestAccSecurityPolicy_PackageVersionsHyphenated(t *testing.T) {
+	pattern := `(^(\(|\[)((\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)|(\s*))\,((\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)|(\s*))(\)|\])$|^\[(\d+\.)?(\d+\.)?(\*|[\dA-Za-z][\dA-Za-z.\-]*)\]$|^[\dA-Za-z][\dA-Za-z.\-]*$)`
+	re := regexp.MustCompile(pattern)
+
+	valid := []string{
+		"(,)",
+		"( , )",
+		"2026.3.31-2",
+		"[2026.3.31-2]",
+		"[1.2.3]",
+		"[1.0.0.0]",
+		"3.10.0",
+		"(1,latest)",
+		"(1.2.3,3.10.2)",
+		"[3.11,)",
+		"[4.0.0]",
+		"(3.2.1,)",
+		"[3.2.1,]",
+	}
+	for _, s := range valid {
+		if !re.MatchString(s) {
+			t.Fatalf("expected package_versions pattern to accept %q", s)
+		}
+	}
+	invalid := []string{"", "[3,,4]", "(1,2,3)", "((1,2))", "[foo"}
+	for _, s := range invalid {
+		if re.MatchString(s) {
+			t.Fatalf("expected package_versions pattern to reject %q", s)
+		}
+	}
+
+	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
+	testData := sdk.MergeMaps(testDataSecurity)
+
+	testData["resource_name"] = resourceName
+	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-hyphen-pkg-%d", testutil.RandomInt())
+	testData["rule_name"] = fmt.Sprintf("test-security-rule-hyphen-%d", testutil.RandomInt())
+	testData["block_unscanned"] = "false"
+	testData["block_active"] = "false"
+	testData["package_name"] = "@shadanai/openclaw"
+	testData["package_type"] = "Npm"
+	testData["package_version_1"] = "2026.3.31-2"
+	testData["package_version_2"] = "[2026.3.31-2]"
+	testData["package_version_3"] = "(,)"
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicyPackages, testData),
+				Check: resource.ComposeTestCheckFunc(
+					verifySecurityPolicy(fqrn, testData, criteriaTypePackageName),
+					resource.TestCheckTypeSetElemAttr(fqrn, "rule.0.criteria.0.package_versions.*", testData["package_version_2"]),
+					resource.TestCheckTypeSetElemAttr(fqrn, "rule.0.criteria.0.package_versions.*", testData["package_version_3"]),
+				),
+			},
+			{
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"author", "created", "modified", "rule.0.actions.0.fail_pull_request"},
+			},
+		},
+	})
+}
+
 func TestAccSecurityPolicy_PackagesIncorrectVersionRangeFails(t *testing.T) {
 	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
 	testData := sdk.MergeMaps(testDataSecurity)
 
-	for _, invalidVersionRange := range []string{"3.10.0", "[3,,4]", "(1,latest)", "[1.0.0.0]"} {
+	for _, invalidVersionRange := range []string{"", "[3,,4]", "(1,2,3)", "((1,2))", "[foo"} {
 		testData["resource_name"] = resourceName
 		testData["policy_name"] = fmt.Sprintf("terraform-security-policy-10-%d", testutil.RandomInt())
 		testData["rule_name"] = fmt.Sprintf("test-security-rule-10-%d", testutil.RandomInt())
 		testData["block_unscanned"] = "false"
 		testData["block_active"] = "false"
 		testData["package_name"] = "nuget://RazorEngine"
-		testData["package_type"] = "nuget"
+		testData["package_type"] = "NuGet"
 		testData["package_version_1"] = invalidVersionRange
 		testData["package_version_2"] = "(3.2.1,)"
 		testData["package_version_3"] = "[3.2.1,]"


### PR DESCRIPTION
## Summary

Relaxes `rule.criteria.package_versions` validation on `xray_security_policy` so version strings accepted by the Xray Policy API (including hyphenated semver-style values) are not rejected at Terraform plan time.

## Problem

Policies such as npm `@shadanai/openclaw` with `package_versions = ["[2026.3.31-2]"]` (or bare `2026.3.31-2`) failed plan with **Invalid Attribute Value Match** / **invalid Range**, while the same criteria work via the Xray REST API and UI.

## Solution

- Replace the overly strict digit-only regex with one that allows alphanumeric tokens with `.` and `-`, bare specific versions, and bounds such as `(1,latest)` where appropriate.
- Update the schema description and validator error hint accordingly.
- **CHANGELOG:** add a **3.1.9** bugfix entry.

## Tests

- **`TestAccSecurityPolicy_PackageVersionsHyphenated`** — Asserts the same regex as the schema (keep in sync with `resource_xray_security_policy.go`), then create/import a policy with `package_versions = ["2026.3.31-2", "[2026.3.31-2]", "(,)"]` and checks all three values in state.
- **`TestAccSecurityPolicy_PackagesIncorrectVersionRangeFails`** — Invalid cases updated to `[3,,4]`, `(1,2,3)`, `((1,2))` so they still expect plan failure under the new pattern.

```bash
TF_ACC=true go test ./pkg/xray/resource/... -run '^TestAccSecurityPolicy_PackageVersionsHyphenated$' -count=1 -v -timeout 1h -p 1
```

## Commit

`e000ef397e3436a1602cfc3449de35c0d843e4be` — Relax the package_versions validation regex to match the Xray API
