### PR TITLE
Fix state drift for exposures min_severity due to API casing mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.9 (April 07, 2026).
+
+BUG FIXES:
+
+* resource/xray_security_policy: Fix state drift for `criteria.exposures.min_severity` when set to `All severities` caused by casing mismatch between Xray API response and provider validator. PR: [#406](https://github.com/jfrog/terraform-provider-xray/pull/406)
+
 ## 3.1.8 (April 01, 2026). Tested on JFrog Platform 11.4.5 (Artifactory 7.133.15, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
 
 BUG FIXES:

--- a/pkg/xray/resource/resource_xray_security_policy.go
+++ b/pkg/xray/resource/resource_xray_security_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jfrog/terraform-provider-shared/util"
-	"github.com/samber/lo"
 )
 
 var _ resource.Resource = &SecurityPolicyResource{}
@@ -106,6 +106,21 @@ func (r SecurityPolicyResource) toAPIModel(ctx context.Context, plan PolicyResou
 	return plan.toAPIModel(ctx, policy, r.toCriteriaAPIModel, toActionsAPIModel)
 }
 
+var severityNormalizationMap = map[string]string{
+	"all severities": "All severities",
+	"critical":       "Critical",
+	"high":           "High",
+	"medium":         "Medium",
+	"low":            "Low",
+}
+
+func NormalizeSeverity(s string) string {
+	if mapped, ok := severityNormalizationMap[strings.ToLower(s)]; ok {
+		return mapped
+	}
+	return s
+}
+
 func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, criteriaAPIModel *PolicyRuleCriteriaAPIModel) (types.List, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
@@ -113,7 +128,7 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 	if criteriaAPIModel != nil {
 		minimumSeverity := types.StringNull()
 		if criteriaAPIModel.MinimumSeverity != "" {
-			minimumSeverity = types.StringValue(criteriaAPIModel.MinimumSeverity)
+			minimumSeverity = types.StringValue(NormalizeSeverity(criteriaAPIModel.MinimumSeverity))
 		}
 
 		cvssRangeList := types.ListNull(cvssRangeElementType)
@@ -149,7 +164,7 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 		if criteriaAPIModel.Exposures != nil {
 			var minSeverity *string
 			if criteriaAPIModel.Exposures.MinSeverity != nil {
-				s := lo.Capitalize(*criteriaAPIModel.Exposures.MinSeverity)
+				s := NormalizeSeverity(*criteriaAPIModel.Exposures.MinSeverity)
 				minSeverity = &s
 			}
 
@@ -323,7 +338,7 @@ var securityPolicyCriteriaBlocks = map[string]schema.Block{
 					Validators: []validator.String{
 						stringvalidator.OneOf("All severities", "Critical", "High", "Medium", "Low"),
 					},
-					MarkdownDescription: "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All Severities`, `Critical`, `High`, `Medium`, `Low`",
+					MarkdownDescription: "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All severities`, `Critical`, `High`, `Medium`, `Low`",
 				},
 				"secrets": schema.BoolAttribute{
 					Optional:    true,
@@ -379,7 +394,7 @@ var securityPolicyCriteriaAttrs = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("cvss_range"),
 			),
 		},
-		Description: "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All Severities`, `Critical`, `High`, `Medium`, `Low`",
+		Description: "The minimum security vulnerability severity that will be impacted by the policy. Valid values: `All severities`, `Critical`, `High`, `Medium`, `Low`",
 	},
 	"fix_version_dependant": schema.BoolAttribute{
 		Optional:    true,

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/util/sdk"
 	"github.com/jfrog/terraform-provider-xray/v3/pkg/acctest"
+	xray "github.com/jfrog/terraform-provider-xray/v3/pkg/xray/resource"
 )
 
 const criteriaTypeCvss = "cvss"
@@ -41,6 +42,38 @@ var testDataSecurity = map[string]string{
 	"block_unscanned":                   "true",
 	"block_active":                      "true",
 	"criteriaType":                      "cvss",
+}
+
+func TestNormalizeSeverity(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"All Severities", "All severities"},
+		{"All severities", "All severities"},
+		{"all severities", "All severities"},
+		{"ALL SEVERITIES", "All severities"},
+		{"Critical", "Critical"},
+		{"critical", "Critical"},
+		{"CRITICAL", "Critical"},
+		{"High", "High"},
+		{"high", "High"},
+		{"HIGH", "High"},
+		{"Medium", "Medium"},
+		{"medium", "Medium"},
+		{"Low", "Low"},
+		{"low", "Low"},
+		{"unknown_value", "unknown_value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := xray.NormalizeSeverity(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeSeverity(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestAccSecurityPolicy_UpgradeFromSDKv2(t *testing.T) {
@@ -889,6 +922,45 @@ func TestAccSecurityPolicy_exposures(t *testing.T) {
 			{
 				Config: util.ExecuteTemplate(fqrn, securityPolicyExposures, testData),
 				Check:  verifySecurityPolicy(fqrn, testData, criteriaTypeExposures),
+			},
+			{
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"author", "created", "modified", "rule.0.actions.0.fail_pull_request"},
+			},
+		},
+	})
+}
+
+func TestAccSecurityPolicy_exposuresAllSeveritiesNoDrift(t *testing.T) {
+	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
+	testData := sdk.MergeMaps(testDataSecurity)
+
+	testData["resource_name"] = resourceName
+	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-allsev-%d", testutil.RandomInt())
+	testData["rule_name"] = fmt.Sprintf("test-security-rule-allsev-%d", testutil.RandomInt())
+	testData["exposures_min_severity"] = "All severities"
+	testData["exposures_secrets"] = "true"
+	testData["exposures_applications"] = "true"
+	testData["exposures_services"] = "true"
+	testData["exposures_iac"] = "true"
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicyExposures, testData),
+				Check:  verifySecurityPolicy(fqrn, testData, criteriaTypeExposures),
+			},
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicyExposures, testData),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ResourceName:            fqrn,


### PR DESCRIPTION
**Summary**

Fix criteria.exposures.min_severity state drift caused by casing mismatch between Xray API response ("All Severities") and Terraform schema validator ("All severities").

Replace lo.Capitalize with a case-insensitive normalization map that converts any API response casing to the validator-expected form. Also apply the same normalization to the top-level CVE min_severity for defensive consistency, and correct the schema documentation.

Fixes workflows where min_severity = "All severities" causes an inconsistent result error on create and perpetual drift on subsequent plan/apply cycles.

Issue Details Type: bug Resource: xray_security_policy Affected versions: 3.x (works correctly in 2.10)

**Details**

The fromCriteriaAPIModel function used lo.Capitalize to normalize the exposures.min_severity value returned by the Xray API. lo.Capitalize only uppercases the first character, so "All Severities" (title case from the API) passed through unchanged. The schema validator expects "All severities" (lowercase s), causing:

An inconsistent result error during terraform apply (policy is created but state write fails)
Perpetual drift on subsequent terraform plan/terraform apply
The fix introduces a NormalizeSeverity function backed by a severityNormalizationMap that lowercases the input and maps it to the canonical validator-expected form. This is applied to both exposures.min_severity and the top-level CVE criteria.min_severity for defensive consistency.

**Test plan**

Added TestNormalizeSeverity unit test covering all severity values with various casing permutations (lowercase, uppercase, title case, mixed)
Added TestAccSecurityPolicy_exposuresAllSeveritiesNoDrift acceptance test that creates a policy with min_severity = "All severities", verifies no drift via plancheck.ExpectEmptyPlan(), and validates import
Existing TestAccSecurityPolicy_exposures, TestAccSecurityPolicy_minSeverity, and TestAccSecurityPolicy_UpgradeFromSDKv2 tests continue to pass
Manually tested with customer's exact Terraform config against live Xray instance: apply succeeds, subsequent plan reports "No changes"
go build ./... and go vet ./... pass with no errors
