### PR TITLE
Add SAST criteria support to xray_security_policy rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.10 (April 13, 2026).
+## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2) with Terraform 1.14.8 and OpenTofu 1.11.6
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.10 (April 13, 2026).
+
+FEATURES:
+
+* resource/xray_security_policy: Add `sast` block to `rule.criteria` for SAST policy rules with `min_severity` support. Only supported by JFrog Advanced Security. PR: [#407](https://github.com/jfrog/terraform-provider-xray/pull/407)
+
 ## 3.1.9 (April 07, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.17, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
 
 IMPROVEMENTS:

--- a/examples/resources/xray_security_policy/resource.tf
+++ b/examples/resources/xray_security_policy/resource.tf
@@ -70,6 +70,41 @@ resource "xray_security_policy" "cvss_score" {
   }
 }
 
+resource "xray_security_policy" "sast" {
+  name        = "test-security-policy-sast"
+  description = "Security policy description"
+  type        = "security"
+  project_key = "testproj"
+
+  rule {
+    name     = "rule-name-sast"
+    priority = 1
+
+    criteria {
+      sast {
+        min_severity = "Low"
+      }
+    }
+
+    actions {
+      webhooks                           = []
+      mails                              = ["test@email.com"]
+      block_release_bundle_distribution  = true
+      fail_build                         = true
+      notify_watch_recipients            = true
+      notify_deployer                    = true
+      create_ticket_enabled              = false // set to true only if Jira integration is enabled
+      fail_pull_request                  = true
+      build_failure_grace_period_in_days = 5     // use only if fail_build is enabled
+
+      block_download {
+        unscanned = true
+        active    = true
+      }
+    }
+  }
+}
+
 resource "xray_security_policy" "malicious_package" {
   name        = "test-security-policy-mal-pkg"
   description = "Security policy description"

--- a/pkg/xray/resource/policies.go
+++ b/pkg/xray/resource/policies.go
@@ -570,6 +570,10 @@ type PolicyExposuresAPIModel struct {
 	Iac          *bool   `json:"iac,omitempty"`
 }
 
+type PolicySASTAPIModel struct {
+	MinSeverity string `json:"min_severity,omitempty"`
+}
+
 type OperationalRiskCriteriaAPIModel struct {
 	UseAndCondition               bool   `json:"use_and_condition"`
 	IsEOL                         bool   `json:"is_eol"`
@@ -591,6 +595,7 @@ type PolicyRuleCriteriaAPIModel struct {
 	MaliciousPackage    *bool                    `json:"malicious_package,omitempty"`
 	VulnerabilityIds    []string                 `json:"vulnerability_ids,omitempty"`
 	Exposures           *PolicyExposuresAPIModel `json:"exposures,omitempty"`
+	SAST                *PolicySASTAPIModel      `json:"sast,omitempty"`
 	PackageName         string                   `json:"package_name,omitempty"`
 	PackageType         string                   `json:"package_type,omitempty"`
 	PackageVersions     []string                 `json:"package_versions,omitempty"`

--- a/pkg/xray/resource/resource_xray_security_policy.go
+++ b/pkg/xray/resource/resource_xray_security_policy.go
@@ -79,6 +79,15 @@ func (r *SecurityPolicyResource) toCriteriaAPIModel(ctx context.Context, criteri
 			}
 		}
 
+		var sast *PolicySASTAPIModel
+		sastElem := attrs["sast"].(types.List).Elements()
+		if len(sastElem) > 0 {
+			sastAttrs := sastElem[0].(types.Object).Attributes()
+			sast = &PolicySASTAPIModel{
+				MinSeverity: sastAttrs["min_severity"].(types.String).ValueString(),
+			}
+		}
+
 		var packageVersions []string
 		d = attrs["package_versions"].(types.List).ElementsAs(ctx, &packageVersions, false)
 		if d.HasError() {
@@ -93,6 +102,7 @@ func (r *SecurityPolicyResource) toCriteriaAPIModel(ctx context.Context, criteri
 			MaliciousPackage:    attrs["malicious_package"].(types.Bool).ValueBoolPointer(),
 			VulnerabilityIds:    vulnerabilityIds,
 			Exposures:           exposures,
+			SAST:                sast,
 			PackageName:         attrs["package_name"].(types.String).ValueString(),
 			PackageType:         attrs["package_type"].(types.String).ValueString(),
 			PackageVersions:     packageVersions,
@@ -193,6 +203,29 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 			exposuresList = es
 		}
 
+		sastList := types.ListNull(sastElementType)
+		if criteriaAPIModel.SAST != nil {
+			sast, d := types.ObjectValue(
+				sastAttrType,
+				map[string]attr.Value{
+					"min_severity": types.StringValue(NormalizeSeverity(criteriaAPIModel.SAST.MinSeverity)),
+				},
+			)
+			if d.HasError() {
+				diags.Append(d...)
+			}
+
+			sl, d := types.ListValue(
+				sastElementType,
+				[]attr.Value{sast},
+			)
+			if d.HasError() {
+				diags.Append(d...)
+			}
+
+			sastList = sl
+		}
+
 		packageName := types.StringNull()
 		if criteriaAPIModel.PackageName != "" {
 			packageName = types.StringValue(criteriaAPIModel.PackageName)
@@ -218,6 +251,7 @@ func (r *SecurityPolicyResource) fromCriteriaAPIModel(ctx context.Context, crite
 				"cvss_range":            cvssRangeList,
 				"vulnerability_ids":     vulnerabilityIDs,
 				"exposures":             exposuresList,
+				"sast":                  sastList,
 				"package_name":          packageName,
 				"package_type":          packageType,
 				"package_versions":      packageVersions,
@@ -266,6 +300,14 @@ var exposuresElementType = types.ObjectType{
 	AttrTypes: exposuresAttrType,
 }
 
+var sastAttrType = map[string]attr.Type{
+	"min_severity": types.StringType,
+}
+
+var sastElementType = types.ObjectType{
+	AttrTypes: sastAttrType,
+}
+
 var securityCriteriaAttrTypes = map[string]attr.Type{
 	"min_severity":          types.StringType,
 	"fix_version_dependant": types.BoolType,
@@ -274,6 +316,7 @@ var securityCriteriaAttrTypes = map[string]attr.Type{
 	"cvss_range":            types.ListType{ElemType: cvssRangeElementType},
 	"vulnerability_ids":     types.ListType{ElemType: types.StringType},
 	"exposures":             types.ListType{ElemType: exposuresElementType},
+	"sast":                  types.ListType{ElemType: sastElementType},
 	"package_name":          types.StringType,
 	"package_type":          types.StringType,
 	"package_versions":      types.ListType{ElemType: types.StringType},
@@ -381,8 +424,48 @@ var securityPolicyCriteriaBlocks = map[string]schema.Block{
 			listvalidator.ConflictsWith(
 				path.MatchRelative().AtParent().AtName("vulnerability_ids"),
 			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("sast"),
+			),
 		},
 		Description: "Creates policy rules for specific exposures.\n\n~>Only supported by JFrog Advanced Security",
+	},
+	"sast": schema.ListNestedBlock{
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"min_severity": schema.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						stringvalidator.OneOf("All severities", "Critical", "High", "Medium", "Low"),
+					},
+					MarkdownDescription: "The minimum SAST vulnerability severity that will be impacted by the policy. Valid values: `All severities`, `Critical`, `High`, `Medium`, `Low`",
+				},
+			},
+		},
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("cvss_range"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("min_severity"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("malicious_package"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("vulnerability_ids"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("exposures"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("package_name"),
+				path.MatchRelative().AtParent().AtName("package_type"),
+				path.MatchRelative().AtParent().AtName("package_versions"),
+			),
+		},
+		Description: "Creates policy rules for SAST (Static Application Security Testing) findings.\n\n~>Only supported by JFrog Advanced Security",
 	},
 }
 
@@ -429,6 +512,9 @@ var securityPolicyCriteriaAttrs = map[string]schema.Attribute{
 			),
 			listvalidator.ConflictsWith(
 				path.MatchRelative().AtParent().AtName("exposures"),
+			),
+			listvalidator.ConflictsWith(
+				path.MatchRelative().AtParent().AtName("sast"),
 			),
 			listvalidator.ConflictsWith(
 				path.MatchRelative().AtParent().AtName("package_name"),

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -22,6 +22,7 @@ const criteriaTypeMaliciousPkg = "malicious_package"
 const criteriaTypeVulnerabilityIds = "vulnerability_ids"
 const criteriaTypeExposures = "exposures"
 const criteriaTypePackageName = "package_name"
+const criteriaTypeSAST = "sast"
 
 var testDataSecurity = map[string]string{
 	"resource_name":                     "",
@@ -1037,6 +1038,62 @@ func TestAccSecurityPolicy_exposuresAllSeveritiesNoDrift(t *testing.T) {
 	})
 }
 
+func TestAccSecurityPolicy_sast(t *testing.T) {
+	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
+	testData := sdk.MergeMaps(testDataSecurity)
+
+	testData["resource_name"] = resourceName
+	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-sast-%d", testutil.RandomInt())
+	testData["rule_name"] = fmt.Sprintf("test-security-rule-sast-%d", testutil.RandomInt())
+	testData["sast_min_severity"] = "Low"
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicySAST, testData),
+				Check:  verifySecurityPolicy(fqrn, testData, criteriaTypeSAST),
+			},
+			{
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"author", "created", "modified", "rule.0.actions.0.fail_pull_request"},
+			},
+		},
+	})
+}
+
+func TestAccSecurityPolicy_sastNoDrift(t *testing.T) {
+	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
+	testData := sdk.MergeMaps(testDataSecurity)
+
+	testData["resource_name"] = resourceName
+	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-sast-nodrift-%d", testutil.RandomInt())
+	testData["rule_name"] = fmt.Sprintf("test-security-rule-sast-nodrift-%d", testutil.RandomInt())
+	testData["sast_min_severity"] = "High"
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicySAST, testData),
+				Check:  verifySecurityPolicy(fqrn, testData, criteriaTypeSAST),
+			},
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicySAST, testData),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccSecurityPolicy_Packages(t *testing.T) {
 	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
 	testData := sdk.MergeMaps(testDataSecurity)
@@ -1307,6 +1364,12 @@ func verifySecurityPolicy(fqrn string, testData map[string]string, criteriaType 
 			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.package_name", testData["package_name"]),
 			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.package_type", testData["package_type"]),
 			resource.TestCheckTypeSetElemAttr(fqrn, "rule.0.criteria.0.package_versions.*", testData["package_version_1"]),
+		)
+	}
+	if criteriaType == criteriaTypeSAST {
+		return resource.ComposeTestCheckFunc(
+			commonCheckList,
+			resource.TestCheckResourceAttr(fqrn, "rule.0.criteria.0.sast.0.min_severity", testData["sast_min_severity"]),
 		)
 	}
 	return nil
@@ -1837,6 +1900,35 @@ const securityPolicyPackages = `resource "xray_security_policy" "{{ .resource_na
 			package_name = "{{ .package_name }}"
 			package_type = "{{ .package_type }}"
 			package_versions = ["{{ .package_version_1 }}", "{{ .package_version_2 }}", "{{ .package_version_3 }}"]
+		}
+		actions {
+			block_release_bundle_distribution = {{ .block_release_bundle_distribution }}
+			block_release_bundle_promotion = {{ .block_release_bundle_promotion }}
+			fail_build = {{ .fail_build }}
+			notify_watch_recipients = {{ .notify_watch_recipients }}
+			notify_deployer = {{ .notify_deployer }}
+			create_ticket_enabled = {{ .create_ticket_enabled }}
+			fail_pull_request = {{ .fail_pull_request }}
+			build_failure_grace_period_in_days = {{ .grace_period_days }}
+			block_download {
+				unscanned = {{ .block_unscanned }}
+				active = {{ .block_active }}
+			}
+		}
+	}
+}`
+
+const securityPolicySAST = `resource "xray_security_policy" "{{ .resource_name }}" {
+	name = "{{ .policy_name }}"
+	description = "{{ .policy_description }}"
+	type = "security"
+	rule {
+		name = "{{ .rule_name }}"
+		priority = 1
+		criteria {
+			sast {
+				min_severity = "{{ .sast_min_severity }}"
+			}
 		}
 		actions {
 			block_release_bundle_distribution = {{ .block_release_bundle_distribution }}


### PR DESCRIPTION
**Feature: Add SAST criteria support to xray_security_policy rules**

**Issue Details**

Type: new-feature
Issue: Enable SAST policy rule creation via Terraform provider (customer request — Xray Terraform provider does not support SAST rules, only UI and API do)
Affected Resources: xray_security_policy

**Files Changed**

pkg/xray/resource/policies.go
pkg/xray/resource/resource_xray_security_policy.go
pkg/xray/resource/resource_xray_security_policy_test.go
examples/resources/xray_security_policy/resource.tf
CHANGELOG.md

**Root Cause**

The xray_security_policy resource supported min_severity, cvss_range, malicious_package, vulnerability_ids, exposures, and package_name/type/versions criteria, but the sast criteria block — supported by the Xray REST API — was not implemented in the provider.

**Fix Approach**

Added PolicySASTAPIModel struct (json:"sast,omitempty") and wired it into PolicyRuleCriteriaAPIModel
Added sast as an optional ListNestedBlock in rule.criteria with a required min_severity attribute (All severities, Critical, High, Medium, Low)
Added ConflictsWith validators on sast for all mutually exclusive criteria types, and symmetrically on vulnerability_ids
Updated toCriteriaAPIModel and fromCriteriaAPIModel to serialize/deserialize the new block
No schema version bump required — follows the same pattern as previous optional block additions (exposures, package_name, applicable_cves_only)

**Changelog**

FEATURES:
* resource/xray_security_policy: Add `sast` block to `rule.criteria` for SAST policy rules with `min_severity` support. Only supported by JFrog Advanced Security. PR: [#407](https://github.com/jfrog/terraform-provider-xray/pull/407)

**Test Plan**


 go build ./... passes
 go vet ./... passes

 TestAccSecurityPolicy_sast — create with min_severity = "Low", verify attributes, import round-trip ✅
 TestAccSecurityPolicy_sastNoDrift — two consecutive plans produce identical state, no spurious diff ✅

 All 35 pre-existing TestAccSecurityPolicy_* tests pass unchanged ✅ (including UpgradeFromSDKv2, exposures, vulnerabilityIds, Packages, CVSS, maliciousPackage, etc.)

 Tested against JFrog Platform (Xray 3.137.27)