### PR TITLE
fix: xray_catalog_labels maximum name limited to 15 characters (GH-403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* resource/xray_catalog_labels: Fix maximum label name length from 15 to 100 characters to match Xray API/UI. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403)
+
 * resource/xray_security_policy: Fix state drift for `criteria.exposures.min_severity` when set to `All severities` caused by casing mismatch between Xray API response and provider validator. PR: [#406](https://github.com/jfrog/terraform-provider-xray/pull/406)
 
 * resource/xray_security_policy: Relax `package_versions` validation so hyphenated and other Xray-supported version strings match the API. Issue: [#402](https://github.com/jfrog/terraform-provider-xray/issues/402) PR: [#405](https://github.com/jfrog/terraform-provider-xray/pull/405)

--- a/pkg/xray/resource/catalog.go
+++ b/pkg/xray/resource/catalog.go
@@ -8,7 +8,7 @@ import (
 const (
 	CatalogGraphQLEndpoint    = "catalog/api/v1/custom/graphql"
 	MaxLabelsPerOperation     = 500
-	MaxLabelNameLength        = 15  // User requirement: max 15 characters
+	MaxLabelNameLength        = 100 // Xray API/UI allows up to 100 characters
 	MaxLabelDescriptionLength = 300 // User requirement: max 300 characters
 )
 

--- a/pkg/xray/resource/resource_catalog_labels_test.go
+++ b/pkg/xray/resource/resource_catalog_labels_test.go
@@ -151,7 +151,7 @@ func TestAccCatalogLabels_LabelNameValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-nameval-", "xray_catalog_labels")
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelNameValidation", `
 resource "xray_catalog_labels" "{{ .name }}" {
-  labels = [ { name = "this-name-is-way-too-long", description = "d1" } ]
+  labels = [ { name = "this-label-name-is-way-too-long-and-exceeds-the-maximum-allowed-length-of-one-hundred-characters-limit", description = "d1" } ]
 }
 `, map[string]string{"name": resName})
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Summary

- Fix `MaxLabelNameLength` constant from `15` to `100` to match the Xray API/UI limit
- Update acceptance test to use a 102-character string (exceeds new 100-char limit) for validation

## Root Cause

The `MaxLabelNameLength` constant in `pkg/xray/resource/catalog.go` was hardcoded to `15`, but the Xray API and UI both support label names up to 100 characters.

## Changes

| File | Change |
|------|--------|
| `pkg/xray/resource/catalog.go` | `MaxLabelNameLength = 15` → `MaxLabelNameLength = 100` |
| `pkg/xray/resource/resource_catalog_labels_test.go` | Test string updated from 25 chars to 102 chars |
| `CHANGELOG.md` | Added bug fix entry |

## Test Plan

- [x] `go build ./...` passes
- [ ] `TestAccCatalogLabels_LabelNameValidation` — verifies 102-char name is rejected
- [ ] `TestAccCatalogLabels_basic` — verifies normal label CRUD still works
- [ ] Manual: create a label with 50+ character name via Terraform

Closes https://github.com/jfrog/terraform-provider-xray/issues/403

Made with [Cursor](https://cursor.com)