### PR TITLE
Fix label field length validation to match api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * resource/xray_security_policy: Add `sast` block to `rule.criteria` for SAST policy rules with `min_severity` support. Only supported by JFrog Advanced Security. PR: [#407](https://github.com/jfrog/terraform-provider-xray/pull/407)
 
+BUG FIXES:
+
+* resource/xray_catalog_labels: Fix `name` and `description` field length validations. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403) PR: [#413](https://github.com/jfrog/terraform-provider-xray/pull/413)
+
 ## 3.1.9 (April 07, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.17, Xray 3.137.27, Catalog 1.35.0) with Terraform 1.14.8 and OpenTofu 1.11.5
 
 IMPROVEMENTS:

--- a/pkg/xray/resource/catalog.go
+++ b/pkg/xray/resource/catalog.go
@@ -8,8 +8,8 @@ import (
 const (
 	CatalogGraphQLEndpoint    = "catalog/api/v1/custom/graphql"
 	MaxLabelsPerOperation     = 500
-	MaxLabelNameLength        = 15  // User requirement: max 15 characters
-	MaxLabelDescriptionLength = 300 // User requirement: max 300 characters
+	MaxLabelNameLength        = 1000  // User requirement: max 1,000 characters
+	MaxLabelDescriptionLength = 10000 // User requirement: max 10,000 characters
 )
 
 // parseGraphQLError extracts meaningful error messages from GraphQL responses

--- a/pkg/xray/resource/resource_catalog_labels_test.go
+++ b/pkg/xray/resource/resource_catalog_labels_test.go
@@ -151,7 +151,7 @@ func TestAccCatalogLabels_LabelNameValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-nameval-", "xray_catalog_labels")
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelNameValidation", `
 resource "xray_catalog_labels" "{{ .name }}" {
-  labels = [ { name = "this-name-is-way-too-long", description = "d1" } ]
+  labels = [ { name = "this-label-name-is-absolutely-too-long-exceeding-the-max-name-length-according-to-the-jfrog-api-and-docs", description = "d1" } ]
 }
 `, map[string]string{"name": resName})
 	resource.Test(t, resource.TestCase{
@@ -165,9 +165,10 @@ resource "xray_catalog_labels" "{{ .name }}" {
 
 func TestAccCatalogLabels_LabelDescriptionValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-descval-", "xray_catalog_labels")
-	// description > 300
-	d := make([]byte, 0, 310)
-	for i := 0; i < 310; i++ {
+	// description > 10,000
+	length := 10010
+	d := make([]byte, 0, length)
+	for i := 0; i < length; i++ {
 		d = append(d, 'a')
 	}
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelDescriptionValidation", `


### PR DESCRIPTION
The catalog label name and description length limits are too small and do not match the constraints of the JFrog Curation API.

The current API limits can be seen in https://docs.jfrog.com/security/docs/graphql-apis#graphql-api-error-messages

I've also confirmed the updated resource works against a dev install of artifactory and curation.

Closes #403
