### PR TITLE
Add Gradle contextual analysis support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* resource/xray_repository_config: Add Gradle support for `vuln_contextual_analysis` on SaaS instances running Xray 3.108.0 or later. PR: [#418](https://github.com/jfrog/terraform-provider-xray/pull/418)
 * provider: Upgrade `github.com/jfrog/terraform-provider-shared` to v1.30.8.
 
 BUG FIXES:

--- a/docs/resources/repository_config.md
+++ b/docs/resources/repository_config.md
@@ -72,7 +72,7 @@ Optional:
 
 - `exposures` (Block Set) Enables Xray to perform scans for multiple categories that cover security issues in your configurations and the usage of open source libraries in your code. Available only to CLOUD (SaaS)/SELF HOSTED for ENTERPRISE X and ENTERPRISE+ with Advanced DevSecOps. Must be set for Docker, Maven, NPM, PyPi, and Terraform Backend package type. (see [below for nested schema](#nestedblock--config--exposures))
 - `retention_in_days` (Number) The artifact will be retained for the number of days you set here, after the artifact is scanned. This will apply to all artifacts in the repository. Can be omitted when `paths_config` is set.
-- `vuln_contextual_analysis` (Boolean) Enables or disables vulnerability contextual analysis. Only for SaaS instances, will be available after Xray 3.59. Must be set for Docker, OCI, and Maven package types.
+- `vuln_contextual_analysis` (Boolean) Enables or disables vulnerability contextual analysis. Only for SaaS instances, will be available after Xray 3.59. Must be set for Docker, OCI, Maven, and Gradle package types.
 
 <a id="nestedblock--config--exposures"></a>
 ### Nested Schema for `config.exposures`

--- a/pkg/xray/resource/resource_xray_repository_config.go
+++ b/pkg/xray/resource/resource_xray_repository_config.go
@@ -259,6 +259,10 @@ var vulnContextualAnalysisPackageTypes = func(xrayVersion string) []string {
 		packageTypes = append(packageTypes, "maven")
 	}
 
+	if ok, err := util.CheckVersion(xrayVersion, "3.108.0"); err == nil && ok {
+		packageTypes = append(packageTypes, "gradle")
+	}
+
 	return packageTypes
 }
 
@@ -508,7 +512,7 @@ var schemaV0 = schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"vuln_contextual_analysis": schema.BoolAttribute{
 						Optional:    true,
-						Description: "Only for SaaS instances, will be available after Xray 3.59. Enables vulnerability contextual analysis. Must be set together with `exposures`. Supported for Docker, OCI, and Maven package types.",
+						Description: "Only for SaaS instances, will be available after Xray 3.59. Enables vulnerability contextual analysis. Must be set together with `exposures`. Supported for Docker, OCI, Maven, and Gradle package types.",
 					},
 					"retention_in_days": schema.Int64Attribute{
 						Optional: true,
@@ -669,7 +673,7 @@ var schemaV1 = schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"vuln_contextual_analysis": schema.BoolAttribute{
 						Optional:    true,
-						Description: "Enables or disables vulnerability contextual analysis. Only for SaaS instances, will be available after Xray 3.59. Must be set for Docker, OCI, and Maven package types.",
+						Description: "Enables or disables vulnerability contextual analysis. Only for SaaS instances, will be available after Xray 3.59. Must be set for Docker, OCI, Maven, and Gradle package types.",
 					},
 					"retention_in_days": schema.Int64Attribute{
 						Optional: true,

--- a/pkg/xray/resource/resource_xray_repository_config_test.go
+++ b/pkg/xray/resource/resource_xray_repository_config_test.go
@@ -277,6 +277,7 @@ func TestAccRepositoryConfig_RepoConfig_Create_VulnContextualAnalysis(t *testing
 	}{
 		{"docker", TestDataRepoConfigDockerTemplate, "3.67.9"},
 		{"maven", TestDataRepoConfigMavenTemplate, "3.77.4"},
+		{"gradle", TestDataRepoConfigGradleTemplate, "3.108.0"},
 	}
 
 	version, err := util.GetXrayVersion(acctest.GetTestResty(t))
@@ -867,6 +868,7 @@ resource "xray_repository_config" "{{ .resource_name }}" {
 
   config {
     retention_in_days        = {{ .retention_in_days }}
+    vuln_contextual_analysis = {{ .vuln_contextual_analysis }}
 
 	exposures {
       scanners_category {


### PR DESCRIPTION
Summary:
- include Gradle in the repository-config package types that keep `vuln_contextual_analysis` in API payloads and state
- update the Gradle acceptance-test fixture to exercise `vuln_contextual_analysis`
- update the checked-in repository config docs to list Gradle support

This follows the existing Gradle JFrog Advanced Security support gate used for exposures/secrets scans.

Verification:
- `gofmt -w pkg/xray/resource/resource_xray_repository_config.go pkg/xray/resource/resource_xray_repository_config_test.go`
- `git diff --check`
- `go test ./pkg/xray/resource -run TestDoesNotExist -count=0`
- `go test ./pkg/xray/resource -run TestAccRepositoryConfig_RepoConfig_Create_VulnContextualAnalysis -count=1 -v` (skips without `JFROG_JAS_DISABLED=false`, as expected for this acceptance test)

Note: I also tried `go generate ./...`, but it could not complete because `tfplugindocs` was unable to download Terraform after checksum signature verification failed with `openpgp: key expired`.

Fixes #416.

Implemented with Codex assistance; I reviewed the issue, source references, and final diff manually before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gradle packages in vulnerability contextual analysis configurations for Xray 3.108.0 and later.

* **Documentation**
  * Updated repository configuration documentation to reflect Gradle support.
  * Recorded the improvement in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->