### PR TITLE
Fix label field length validation to match api(#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.11 (Jun 9, 2026).
+
+BUG FIXES:
+
+* resource/xray_catalog_labels: Fix `name` and `description` field length validations. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403) PR: [#420](https://github.com/jfrog/terraform-provider-xray/pull/420)
+
 ## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2) with Terraform 1.14.8 and OpenTofu 1.11.6
 
 FEATURES:

--- a/pkg/xray/resource/catalog.go
+++ b/pkg/xray/resource/catalog.go
@@ -8,8 +8,8 @@ import (
 const (
 	CatalogGraphQLEndpoint    = "catalog/api/v1/custom/graphql"
 	MaxLabelsPerOperation     = 500
-	MaxLabelNameLength        = 15  // User requirement: max 15 characters
-	MaxLabelDescriptionLength = 300 // User requirement: max 300 characters
+	MaxLabelNameLength        = 1000  // User requirement: max 1,000 characters
+	MaxLabelDescriptionLength = 10000 // User requirement: max 10,000 characters
 )
 
 // parseGraphQLError extracts meaningful error messages from GraphQL responses

--- a/pkg/xray/resource/resource_catalog_labels_test.go
+++ b/pkg/xray/resource/resource_catalog_labels_test.go
@@ -151,7 +151,7 @@ func TestAccCatalogLabels_LabelNameValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-nameval-", "xray_catalog_labels")
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelNameValidation", `
 resource "xray_catalog_labels" "{{ .name }}" {
-  labels = [ { name = "this-name-is-way-too-long", description = "d1" } ]
+  labels = [ { name = "this-label-name-is-absolutely-too-long-exceeding-the-max-name-length-according-to-the-jfrog-api-and-docs", description = "d1" } ]
 }
 `, map[string]string{"name": resName})
 	resource.Test(t, resource.TestCase{
@@ -165,9 +165,10 @@ resource "xray_catalog_labels" "{{ .name }}" {
 
 func TestAccCatalogLabels_LabelDescriptionValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-descval-", "xray_catalog_labels")
-	// description > 300
-	d := make([]byte, 0, 310)
-	for i := 0; i < 310; i++ {
+	// description > 10,000
+	length := 10010
+	d := make([]byte, 0, length)
+	for i := 0; i < length; i++ {
 		d = append(d, 'a')
 	}
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelDescriptionValidation", `

--- a/pkg/xray/resource/resource_catalog_labels_test.go
+++ b/pkg/xray/resource/resource_catalog_labels_test.go
@@ -149,11 +149,17 @@ resource "xray_catalog_labels" "{{ .name }}" {
 
 func TestAccCatalogLabels_LabelNameValidation(t *testing.T) {
 	_, _, resName := testutil.MkNames("catalog-labels-nameval-", "xray_catalog_labels")
+	// name > 1,000
+	length := 1010
+	n := make([]byte, 0, length)
+	for i := 0; i < length; i++ {
+		n = append(n, 'a')
+	}
 	cfg := util.ExecuteTemplate("TestAccCatalogLabels_LabelNameValidation", `
 resource "xray_catalog_labels" "{{ .name }}" {
-  labels = [ { name = "this-label-name-is-absolutely-too-long-exceeding-the-max-name-length-according-to-the-jfrog-api-and-docs", description = "d1" } ]
+  labels = [ { name = "{{ .longName }}", description = "d1" } ]
 }
-`, map[string]string{"name": resName})
+`, map[string]string{"name": resName, "longName": string(n)})
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{{


### PR DESCRIPTION
# Fix label field length validation to match API

Closes #403

## Problem

The `xray_catalog_labels` resource validates `name` and `description` fields with limits that are far too restrictive:

- `name`: capped at **15 characters**
- `description`: capped at **300 characters**

The actual JFrog Curation API accepts up to **1,000 characters** for name and **10,000 characters** for description (as documented in the [GraphQL API error messages](https://docs.jfrog.com/security/docs/graphql-apis#graphql-api-error-messages)). Users creating labels with names longer than 15 characters get a Terraform validation error even though the API would accept them.

## Solution

Update the validation constants to match the real API limits:

| Field | Before | After |
|-------|--------|-------|
| `MaxLabelNameLength` | 15 | 1,000 |
| `MaxLabelDescriptionLength` | 300 | 10,000 |

## Changes

- **Validation fix:** `pkg/xray/resource/catalog.go` — update `MaxLabelNameLength` and `MaxLabelDescriptionLength` constants.
- **Tests:** `pkg/xray/resource/resource_catalog_labels_test.go` — update name and description validation tests to use strings that exceed the new limits.
- **CHANGELOG:** Bug fix entry for 3.1.10 release.

## Testing

- Acceptance tests updated to generate inputs exceeding the new limits so the validation-error tests remain meaningful.
- PR author confirmed the updated resource works against a dev install of Artifactory and Curation.
