### PR TITLE
fix: preserve colon package names in catalog label assignments(#417)

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -229,6 +229,31 @@ jobs:
           echo "::add-mask::$JFROG_ACCESS_TOKEN"
           echo "JFROG_ACCESS_TOKEN=$JFROG_ACCESS_TOKEN" >> "$GITHUB_ENV"
 
+      - name: Wait for Catalog API to be ready
+        run: |
+          # `kubectl rollout status` only confirms the Catalog pod passed its
+          # readiness probe. The provider's catalog resources additionally
+          # require /catalog/api/v1/system/app_health to report code "OK" (DB
+          # connection, entitlements, etc.), which lags well behind pod-ready.
+          # Poll that same endpoint so catalog tests don't run before it's healthy.
+          echo "Waiting for Catalog app_health to report OK..."
+          for i in $(seq 1 30); do
+            CODE=$(curl -s "${JFROG_URL}/catalog/api/v1/system/app_health" \
+              --header "Authorization: Bearer ${JFROG_ACCESS_TOKEN}" \
+              | jq -r '.code // empty' 2>/dev/null)
+            if [ "$CODE" = "OK" ]; then
+              echo "Catalog is healthy (attempt $i/30)"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "Catalog did not become healthy in time (last code: '$CODE')"
+              exit 1
+            fi
+            echo "Attempt $i/30: catalog health code '$CODE'. Waiting 20s..."
+            sleep 20
+          done
+
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BUG FIXES:
 
 * resource/xray_catalog_labels: Fix `name` and `description` field length validations. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403) PR: [#420](https://github.com/jfrog/terraform-provider-xray/pull/420)
 
-## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2). Tested on JFrog Platform 11.5.4 (Artifactory 7.146.15, Xray 3.143.26, Catalog 1.40.0). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.7 (Artifactory 7.146.25, Xray 3.143.30, Catalog 1.42.0) with Terraform 1.15.8 and OpenTofu 1.12.3
+## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2). 
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 3.1.11 (Jun 9, 2026).
+## 3.1.11(Jun 9, 2026).
+
+BUG FIXES:
+
+* resource/xray_catalog_labels: Preserve package names containing `:` when updating package version assignments. Issue: [#415](https://github.com/jfrog/terraform-provider-xray/issues/415) PR: [#417](https://github.com/jfrog/terraform-provider-xray/pull/417)
+
+## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2). Tested on JFrog Platform 11.5.4 (Artifactory 7.146.15, Xray 3.143.26, Catalog 1.40.0). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3) with Terraform 1.15.6 and OpenTofu 1.12.2
 
 BUG FIXES:
 
 * resource/xray_catalog_labels: Fix `name` and `description` field length validations. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403) PR: [#420](https://github.com/jfrog/terraform-provider-xray/pull/420)
-
-## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2) with Terraform 1.14.8 and OpenTofu 1.11.6
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BUG FIXES:
 
 * resource/xray_catalog_labels: Fix `name` and `description` field length validations. Issue: [#403](https://github.com/jfrog/terraform-provider-xray/issues/403) PR: [#420](https://github.com/jfrog/terraform-provider-xray/pull/420)
 
-## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2). Tested on JFrog Platform 11.5.4 (Artifactory 7.146.15, Xray 3.143.26, Catalog 1.40.0). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3) with Terraform 1.15.6 and OpenTofu 1.12.2
+## 3.1.10 (April 13, 2026). Tested on JFrog Platform 11.4.6 (Artifactory 7.133.18, Xray 3.137.27, Catalog 1.35.2). Tested on JFrog Platform 11.5.4 (Artifactory 7.146.15, Xray 3.143.26, Catalog 1.40.0). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.5 (Artifactory 7.146.17, Xray 3.143.27, Catalog 1.40.3). Tested on JFrog Platform 11.5.7 (Artifactory 7.146.25, Xray 3.143.30, Catalog 1.42.0) with Terraform 1.15.8 and OpenTofu 1.12.3
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_catalog_labels.go
+++ b/pkg/xray/resource/resource_catalog_labels.go
@@ -104,6 +104,20 @@ type versionAssignmentExpanded struct {
 	version     string
 }
 
+type versionAssignmentKey struct {
+	packageName string
+	packageType string
+	version     string
+}
+
+func newVersionAssignmentKey(packageName, packageType, version string) versionAssignmentKey {
+	return versionAssignmentKey{
+		packageName: packageName,
+		packageType: packageType,
+		version:     version,
+	}
+}
+
 func (r *CatalogLabelsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
@@ -383,7 +397,7 @@ func (r *CatalogLabelsResource) validatePackageVersionAssignmentRedundancyInPlan
 	}
 
 	// Build set of versions present in state (if provided)
-	stateKeys := make(map[string]struct{})
+	stateKeys := make(map[versionAssignmentKey]struct{})
 	if state != nil && !state.VersionAssignments.IsNull() && !state.VersionAssignments.IsUnknown() {
 		var sassign []VersionAssignmentModel
 		if diags := state.VersionAssignments.ElementsAs(ctx, &sassign, false); !diags.HasError() {
@@ -392,7 +406,7 @@ func (r *CatalogLabelsResource) validatePackageVersionAssignmentRedundancyInPlan
 				if !a.Versions.IsNull() && !a.Versions.IsUnknown() && len(a.Versions.Elements()) > 0 {
 					if d2 := a.Versions.ElementsAs(ctx, &vs, false); !d2.HasError() {
 						for _, v := range vs {
-							key := fmt.Sprintf("%s:%s:%s", a.PackageName.ValueString(), a.PackageType.ValueString(), v)
+							key := newVersionAssignmentKey(a.PackageName.ValueString(), a.PackageType.ValueString(), v)
 							stateKeys[key] = struct{}{}
 						}
 					}
@@ -419,7 +433,7 @@ func (r *CatalogLabelsResource) validatePackageVersionAssignmentRedundancyInPlan
 			}
 			if len(assigned) > 0 {
 				// Skip error if this exact package:version is already tracked in state
-				key := fmt.Sprintf("%s:%s:%s", a.PackageName.ValueString(), a.PackageType.ValueString(), v)
+				key := newVersionAssignmentKey(a.PackageName.ValueString(), a.PackageType.ValueString(), v)
 				if _, ok := stateKeys[key]; ok {
 					continue
 				}
@@ -1327,25 +1341,25 @@ func (r *CatalogLabelsResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Expand to per-version mapping
-	planVerMap := map[string]string{} // key -> label
+	planVerMap := map[versionAssignmentKey]string{} // key -> label
 	for _, a := range planVers {
 		var vs []string
 		if !a.Versions.IsNull() && !a.Versions.IsUnknown() && len(a.Versions.Elements()) > 0 {
 			if diags := a.Versions.ElementsAs(ctx, &vs, false); !diags.HasError() {
 				for _, v := range vs {
-					key := fmt.Sprintf("%s:%s:%s", a.PackageName.ValueString(), a.PackageType.ValueString(), v)
+					key := newVersionAssignmentKey(a.PackageName.ValueString(), a.PackageType.ValueString(), v)
 					planVerMap[key] = a.LabelName.ValueString()
 				}
 			}
 		}
 	}
-	stateVerMap := map[string]string{}
+	stateVerMap := map[versionAssignmentKey]string{}
 	for _, a := range stateVers {
 		var vs []string
 		if !a.Versions.IsNull() && !a.Versions.IsUnknown() && len(a.Versions.Elements()) > 0 {
 			if diags := a.Versions.ElementsAs(ctx, &vs, false); !diags.HasError() {
 				for _, v := range vs {
-					key := fmt.Sprintf("%s:%s:%s", a.PackageName.ValueString(), a.PackageType.ValueString(), v)
+					key := newVersionAssignmentKey(a.PackageName.ValueString(), a.PackageType.ValueString(), v)
 					stateVerMap[key] = a.LabelName.ValueString()
 				}
 			}
@@ -1358,14 +1372,12 @@ func (r *CatalogLabelsResource) Update(ctx context.Context, req resource.UpdateR
 		var toRemove []VersionAssignmentModel
 		for key, stateLabel := range stateVerMap {
 			if _, ok := planVerMap[key]; !ok {
-				parts := strings.SplitN(key, ":", 3)
-				pkgName, pkgType, version := parts[0], parts[1], parts[2]
 				vm := VersionAssignmentModel{
 					LabelName:   types.StringValue(stateLabel),
-					PackageName: types.StringValue(pkgName),
-					PackageType: types.StringValue(pkgType),
+					PackageName: types.StringValue(key.packageName),
+					PackageType: types.StringValue(key.packageType),
 				}
-				versSet, _ := types.SetValueFrom(ctx, types.StringType, []string{version})
+				versSet, _ := types.SetValueFrom(ctx, types.StringType, []string{key.version})
 				vm.Versions = versSet
 				toRemove = append(toRemove, vm)
 			}
@@ -1386,15 +1398,13 @@ func (r *CatalogLabelsResource) Update(ctx context.Context, req resource.UpdateR
 		var toAdd []VersionAssignmentModel
 		for key, planLabel := range planVerMap {
 			stateLabel, ok := stateVerMap[key]
-			parts := strings.SplitN(key, ":", 3)
-			pkgName, pkgType, version := parts[0], parts[1], parts[2]
 			if !ok || stateLabel != planLabel {
 				vm := VersionAssignmentModel{
 					LabelName:   types.StringValue(planLabel),
-					PackageName: types.StringValue(pkgName),
-					PackageType: types.StringValue(pkgType),
+					PackageName: types.StringValue(key.packageName),
+					PackageType: types.StringValue(key.packageType),
 				}
-				versSet, _ := types.SetValueFrom(ctx, types.StringType, []string{version})
+				versSet, _ := types.SetValueFrom(ctx, types.StringType, []string{key.version})
 				vm.Versions = versSet
 				toAdd = append(toAdd, vm)
 			}

--- a/pkg/xray/resource/resource_catalog_version_assignment_key_test.go
+++ b/pkg/xray/resource/resource_catalog_version_assignment_key_test.go
@@ -1,0 +1,17 @@
+package xray
+
+import "testing"
+
+func TestNewVersionAssignmentKeyKeepsColonPackageNameIntact(t *testing.T) {
+	key := newVersionAssignmentKey("mysql:mysql-connector-java", "maven", "8.0.28")
+
+	if key.packageName != "mysql:mysql-connector-java" {
+		t.Fatalf("expected package name with colon to be preserved, got %q", key.packageName)
+	}
+	if key.packageType != "maven" {
+		t.Fatalf("expected package type maven, got %q", key.packageType)
+	}
+	if key.version != "8.0.28" {
+		t.Fatalf("expected version 8.0.28, got %q", key.version)
+	}
+}


### PR DESCRIPTION
# Fix version assignments when package name contains colon

Closes #415

## Problem

Maven package names use `group:artifact` format (e.g., `mysql:mysql-connector-java`). The Update path builds composite map keys using `:` as separator:

```go
key := fmt.Sprintf("%s:%s:%s", packageName, packageType, version)
// "mysql:mysql-connector-java:maven:8.0.28"
```

Then decomposes them with `strings.SplitN(key, ":", 3)`, which produces:

```go
// pkgName = "mysql"                    ← WRONG
// pkgType = "mysql-connector-java"     ← WRONG
// version = "maven:8.0.28"            ← WRONG
```

This corrupts package name, type, and version on any Update or Destroy operation. Create works fine (uses original model values), so the bug is silent — users think the assignment succeeded.

## Solution

Introduce a `versionAssignmentKey` struct (same pattern as the existing `pkgKey` struct used for package assignments):

```go
type versionAssignmentKey struct {
    packageName string
    packageType string
    version     string
}
```

This eliminates the `fmt.Sprintf` → `strings.SplitN` round-trip entirely. Package names with colons are preserved as-is.

## Changes

- **Bug fix:** `pkg/xray/resource/resource_catalog_labels.go` — replace string map keys with `versionAssignmentKey` struct in `validatePackageVersionAssignmentRedundancyInPlan` and `Update` diff logic. Remove both `strings.SplitN(key, ":", 3)` calls.
- **Unit test:** `pkg/xray/resource/resource_catalog_version_assignment_key_test.go` — verify colon in package name is preserved.
- **CHANGELOG:** Bug fix entry for 3.1.11.

## Backward compatibility

No breaking changes. The struct key is an ephemeral in-memory map key — never persisted to `.tfstate`. The state file format, GraphQL mutations, and provider schema are all unchanged.

| Customer scenario | Impact |
|---|---|
| No colons in package names (npm, PyPI, Go, Docker) | Zero change |
| Colons in package names (Maven) | Goes from broken to working |

## Testing

- `go build ./...` — passes
- `go vet ./pkg/xray/...` — passes
- Unit test `TestNewVersionAssignmentKeyKeepsColonPackageNameIntact` — passes
- Full acceptance tests require a live JFrog Platform with Catalog enabled
