### PR TITLE
Handle soft-deleted ignore rules in Read to prevent state drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * data/xray_curation_condition: Add a new data source which looks up a built-in or custom Curation condition by its exact name (case-sensitive) and exposes its numeric `id`, so `xray_curation_policy.condition_id` no longer has to be hard-coded to a raw numeric ID. Issue: JTFPR-341 PR: [#452](https://github.com/jfrog/terraform-provider-xray/pull/452)
 
+BUG FIXES:
+
+* resource/xray_ignore_rule: Fix `Read` to detect soft-deleted ignore rules. Xray returns HTTP 200 with `deleted_at` and `deleted_by` fields instead of 404 when an ignore rule has been deleted. The provider now checks for these fields and removes the resource from state, preventing permanent state drift. Issue: [#423](https://github.com/jfrog/terraform-provider-xray/issues/423) PR: [#424](https://github.com/jfrog/terraform-provider-xray/pull/424)
+
 ## 3.1.13 (Aug 21, 2026). Tested on JFrog Platform 11.6.1 (Artifactory 7.161.16, Xray 3.150.24, Catalog 1.44.0) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 FEATURES:

--- a/pkg/xray/resource/resource_xray_ignore_rule.go
+++ b/pkg/xray/resource/resource_xray_ignore_rule.go
@@ -564,6 +564,8 @@ type IgnoreRuleAPIModel struct {
 	IsExpired     bool                  `json:"is_expired,omitempty"`
 	Notes         string                `json:"notes"`
 	ExpiresAt     *time.Time            `json:"expires_at,omitempty"`
+	DeletedBy     string                `json:"deleted_by,omitempty"`
+	DeletedAt     *time.Time            `json:"deleted_at,omitempty"`
 	IgnoreFilters IgnoreFiltersAPIModel `json:"ignore_filters"`
 }
 
@@ -1058,6 +1060,13 @@ func (r *IgnoreRuleResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	if response.IsError() {
 		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	// Xray soft-deletes ignore rules: the API returns 200 with deleted_at
+	// and deleted_by fields instead of 404. Treat as deleted.
+	if ignoreRule.DeletedAt != nil {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/pkg/xray/resource/resource_xray_ignore_rule_test.go
+++ b/pkg/xray/resource/resource_xray_ignore_rule_test.go
@@ -932,6 +932,73 @@ func TestAccIgnoreRule_release_bundle(t *testing.T) {
 	})
 }
 
+// TestAccIgnoreRule_SoftDeleted verifies that the provider detects
+// soft-deleted ignore rules and removes them from state. Xray soft-deletes
+// ignore rules: the API returns HTTP 200 with deleted_at and deleted_by
+// fields instead of 404. Without handling this, the provider never detects
+// the deletion and Terraform state drifts from reality.
+func TestAccIgnoreRule_SoftDeleted(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("ignore-rule-", "xray_ignore_rule")
+	expirationDate := time.Now().Add(time.Hour * 48)
+
+	config := util.ExecuteTemplate("TestAccIgnoreRule_SoftDeleted", `
+		resource "xray_ignore_rule" "{{ .name }}" {
+		  notes            = "test soft-delete detection"
+		  expiration_date  = "{{ .expirationDate }}"
+		  vulnerabilities  = ["any"]
+		  cves             = ["any"]
+
+		  artifact {
+		    name    = "fake-name"
+		    version = "fake-version"
+		    path    = "fake-path/"
+		  }
+		}
+	`, map[string]interface{}{
+		"name":           name,
+		"expirationDate": expirationDate.Format("2006-01-02"),
+	})
+
+	var ruleID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", testCheckIgnoreRule),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(fqrn, "id"),
+					resource.TestCheckResourceAttrWith(fqrn, "id", func(value string) error {
+						ruleID = value
+						return nil
+					}),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Delete the ignore rule out of band via API.
+					// Xray soft-deletes: the GET will return 200 with
+					// deleted_at/deleted_by instead of 404.
+					restyClient := acctest.GetTestResty(t)
+					resp, err := restyClient.R().
+						SetPathParam("id", ruleID).
+						Delete("xray/api/v1/ignore_rules/{id}")
+					if err != nil {
+						t.Fatalf("failed to delete ignore rule %q out of band: %v", ruleID, err)
+					}
+					if resp.IsError() {
+						t.Fatalf("failed to delete ignore rule %q out of band: %s", ruleID, resp.String())
+					}
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // testCheckIgnoreRule fetches the supposingly deleted ignore rule and verify it has been deleted
 // Xray applies soft delete to ignore rule and adds 'deleted_by' and 'deleted_at'
 // fields to the payload after a rule is deleted


### PR DESCRIPTION
## Description

Xray soft-deletes ignore rules: the API returns HTTP 200 with `deleted_at` and `deleted_by` fields instead of 404. The provider only checked for 404, so soft-deleted rules were never detected as removed, causing permanent Terraform state drift.

## Changes

- Add `deleted_by` and `deleted_at` fields to `IgnoreRuleAPIModel`
- Check `deleted_at` in `Read()` after the HTTP 404 check; when set, call `resp.State.RemoveResource(ctx)`
- Add acceptance test `TestAccIgnoreRule_SoftDeleted` that creates a rule, deletes it out of band via the API, and verifies the provider detects the soft-delete via `PlanOnly` + `ExpectNonEmptyPlan`
- Update CHANGELOG.md

## Notes

The existing `testCheckIgnoreRule` test helper (used by `CheckDestroy`) already handles soft-deletion by checking `deleted_at` — this fix brings the provider's `Read` path in line with that behavior.

Fixes #423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection of ignore rules that were soft-deleted through the Xray API.
  * Deleted rules are now removed from managed state, preventing configuration drift and enabling accurate plan updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->