### PR TITLE
Make db_sync_updates_time optional in xray_settings resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ BUG FIXES:
 
 * resource/xray_repository_config: Fix perpetual diff on the `paths_config` block when `pattern.exclude` is not set. The API returns an empty string for an unset exclusion, which was stored in state as an empty string instead of null, so every `terraform plan` showed the whole `paths_config` block being removed and re-added.
 
+* resource/xray_settings: Make `db_sync_updates_time` attribute optional so users can configure Artifactory/Xray integration settings without being forced to specify the internal DB sync schedule. When omitted, the provider preserves the existing server value. Issue: [#425](https://github.com/jfrog/terraform-provider-xray/issues/425) PR: [#426](https://github.com/jfrog/terraform-provider-xray/pull/426)
+
 * resource/xray_curation_policy: Fix false `Decision owners required` validation error when `decision_owners` is sourced from another resource, module variable, or other value that is unknown until apply, while `waiver_request_config = "manual"`. The `decisionOwnersRequiredValidator` now skips unknown values and defers validation to the plan phase. Issue: [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)
 
 * resource/xray_curation_policy: Add `block_from_cache` attribute so the "Enforce policy on cached packages" setting is read from and written to the API instead of being silently reset to `false` on every update. Issue: [#431](https://github.com/jfrog/terraform-provider-xray/issues/431) PR: [#435](https://github.com/jfrog/terraform-provider-xray/pull/435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * data/xray_curation_condition: Add a new data source which looks up a built-in or custom Curation condition by its exact name (case-sensitive) and exposes its numeric `id`, so `xray_curation_policy.condition_id` no longer has to be hard-coded to a raw numeric ID. Issue: JTFPR-341 PR: [#452](https://github.com/jfrog/terraform-provider-xray/pull/452)
 
+BUG FIXES:
+
+* resource/xray_settings: Make `db_sync_updates_time` attribute optional so users can configure Artifactory/Xray integration settings without being forced to specify the internal DB sync schedule. When omitted, the provider preserves the existing server value. Issue: [#425](https://github.com/jfrog/terraform-provider-xray/issues/425) PR: [#426](https://github.com/jfrog/terraform-provider-xray/pull/426)
+
 ## 3.1.13 (Aug 21, 2026). Tested on JFrog Platform 11.6.1 (Artifactory 7.161.16, Xray 3.150.24, Catalog 1.44.0) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 FEATURES:
@@ -54,8 +58,6 @@ SECURITY:
 BUG FIXES:
 
 * resource/xray_repository_config: Fix perpetual diff on the `paths_config` block when `pattern.exclude` is not set. The API returns an empty string for an unset exclusion, which was stored in state as an empty string instead of null, so every `terraform plan` showed the whole `paths_config` block being removed and re-added.
-
-* resource/xray_settings: Make `db_sync_updates_time` attribute optional so users can configure Artifactory/Xray integration settings without being forced to specify the internal DB sync schedule. When omitted, the provider preserves the existing server value. Issue: [#425](https://github.com/jfrog/terraform-provider-xray/issues/425) PR: [#426](https://github.com/jfrog/terraform-provider-xray/pull/426)
 
 * resource/xray_curation_policy: Fix false `Decision owners required` validation error when `decision_owners` is sourced from another resource, module variable, or other value that is unknown until apply, while `waiver_request_config = "manual"`. The `decisionOwnersRequiredValidator` now skips unknown values and defers validation to the plan phase. Issue: [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)
 

--- a/pkg/xray/resource/resource_xray_settings.go
+++ b/pkg/xray/resource/resource_xray_settings.go
@@ -86,11 +86,12 @@ func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 			"db_sync_updates_time": schema.StringAttribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^([0-1][0-9]|[2][0-3]):([0-5][0-9])$`), "Wrong format input, expected valid hour:minutes (HH:mm) form"),
 				},
-				Description: "The time of the Xray DB sync daily update job. Format `HH:mm`",
+				Description: "The time of the Xray DB sync daily update job. Format `HH:mm`. If not set, the existing server value is preserved.",
 			},
 			"enabled": schema.BoolAttribute{
 				Optional:    true,
@@ -167,6 +168,27 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// If db_sync_updates_time is not in config, read the current server value
+	// so the Computed attribute is populated in state.
+	if plan.DBSyncUpdateTime.IsNull() || plan.DBSyncUpdateTime.IsUnknown() {
+		var currentDbSyncTime DbSyncDailyUpdatesTimeAPIModel
+		response, err = request.
+			SetResult(&currentDbSyncTime).
+			Get(DBSyncEndPoint)
+		if err != nil {
+			utilfw.UnableToCreateResourceError(resp, err.Error())
+			return
+		}
+		if response.IsError() {
+			utilfw.UnableToCreateResourceError(resp, response.String())
+			return
+		}
+		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime.DbSyncTime)
+		plan.ID = types.StringValue("settings")
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
 	dbSyncTime := DbSyncDailyUpdatesTimeAPIModel{
 		DbSyncTime: plan.DBSyncUpdateTime.ValueString(),
 	}
@@ -184,7 +206,7 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	plan.ID = types.StringValue(dbSyncTime.DbSyncTime)
+	plan.ID = types.StringValue("settings")
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -274,6 +296,27 @@ func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	// If db_sync_updates_time is not in config, read the current server value
+	// so the Computed attribute is populated in state.
+	if plan.DBSyncUpdateTime.IsNull() || plan.DBSyncUpdateTime.IsUnknown() {
+		var currentDbSyncTime DbSyncDailyUpdatesTimeAPIModel
+		response, err = request.
+			SetResult(&currentDbSyncTime).
+			Get(DBSyncEndPoint)
+		if err != nil {
+			utilfw.UnableToUpdateResourceError(resp, err.Error())
+			return
+		}
+		if response.IsError() {
+			utilfw.UnableToUpdateResourceError(resp, response.String())
+			return
+		}
+		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime.DbSyncTime)
+		plan.ID = types.StringValue("settings")
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
 	dbSyncTime := DbSyncDailyUpdatesTimeAPIModel{
 		DbSyncTime: plan.DBSyncUpdateTime.ValueString(),
 	}
@@ -289,7 +332,7 @@ func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	plan.ID = types.StringValue(dbSyncTime.DbSyncTime)
+	plan.ID = types.StringValue("settings")
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/pkg/xray/resource/resource_xray_settings.go
+++ b/pkg/xray/resource/resource_xray_settings.go
@@ -2,9 +2,11 @@ package xray
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -76,6 +78,22 @@ type DbSyncDailyUpdatesTimeErrorAPIModel struct {
 	Error string `json:"error"`
 }
 
+// readDBSyncUpdateTime retrieves the current DB synchronization schedule from Xray.
+func readDBSyncUpdateTime(request *resty.Request) (string, error) {
+	var dbSyncTime DbSyncDailyUpdatesTimeAPIModel
+	response, err := request.
+		SetResult(&dbSyncTime).
+		Get(DBSyncEndPoint)
+	if err != nil {
+		return "", err
+	}
+	if response.IsError() {
+		return "", errors.New(response.String())
+	}
+
+	return dbSyncTime.DbSyncTime, nil
+}
+
 func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
@@ -136,6 +154,7 @@ func (r *SettingsResource) Configure(ctx context.Context, req resource.Configure
 	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
 }
 
+// Create configures Xray settings and records their current state.
 func (r *SettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
 
@@ -171,19 +190,12 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 	// If db_sync_updates_time is not in config, read the current server value
 	// so the Computed attribute is populated in state.
 	if plan.DBSyncUpdateTime.IsNull() || plan.DBSyncUpdateTime.IsUnknown() {
-		var currentDbSyncTime DbSyncDailyUpdatesTimeAPIModel
-		response, err = request.
-			SetResult(&currentDbSyncTime).
-			Get(DBSyncEndPoint)
+		currentDbSyncTime, err := readDBSyncUpdateTime(request)
 		if err != nil {
 			utilfw.UnableToCreateResourceError(resp, err.Error())
 			return
 		}
-		if response.IsError() {
-			utilfw.UnableToCreateResourceError(resp, response.String())
-			return
-		}
-		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime.DbSyncTime)
+		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime)
 		plan.ID = types.StringValue("settings")
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		return
@@ -212,6 +224,7 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
+// Read refreshes Xray settings in Terraform state.
 func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
 
@@ -245,25 +258,19 @@ func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, r
 	state.BlockUnfinishedScansTimeout = types.Int64Value(settings.BlockUnfinishedScansTimeout)
 	state.BlockUnscannedTimeout = types.Int64Value(settings.BlockUnscannedTimeout)
 
-	var dbSyncTime DbSyncDailyUpdatesTimeAPIModel
-	response, err = request.
-		SetResult(&dbSyncTime).
-		Get(DBSyncEndPoint)
+	dbSyncTime, err := readDBSyncUpdateTime(request)
 	if err != nil {
 		utilfw.UnableToRefreshResourceError(resp, fmt.Sprintf("failed to retrieve data from API during Read: %s", err.Error()))
 		return
 	}
-	if response.IsError() {
-		utilfw.UnableToRefreshResourceError(resp, fmt.Sprintf("failed to retrieve data from API during Read: %s", response.String()))
-		return
-	}
 
-	state.DBSyncUpdateTime = types.StringValue(dbSyncTime.DbSyncTime)
+	state.DBSyncUpdateTime = types.StringValue(dbSyncTime)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
+// Update applies planned changes to Xray settings and records their resulting state.
 func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	go util.SendUsageResourceUpdate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
 
@@ -299,19 +306,12 @@ func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateReques
 	// If db_sync_updates_time is not in config, read the current server value
 	// so the Computed attribute is populated in state.
 	if plan.DBSyncUpdateTime.IsNull() || plan.DBSyncUpdateTime.IsUnknown() {
-		var currentDbSyncTime DbSyncDailyUpdatesTimeAPIModel
-		response, err = request.
-			SetResult(&currentDbSyncTime).
-			Get(DBSyncEndPoint)
+		currentDbSyncTime, err := readDBSyncUpdateTime(request)
 		if err != nil {
 			utilfw.UnableToUpdateResourceError(resp, err.Error())
 			return
 		}
-		if response.IsError() {
-			utilfw.UnableToUpdateResourceError(resp, response.String())
-			return
-		}
-		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime.DbSyncTime)
+		plan.DBSyncUpdateTime = types.StringValue(currentDbSyncTime)
 		plan.ID = types.StringValue("settings")
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		return

--- a/pkg/xray/resource/resource_xray_settings_test.go
+++ b/pkg/xray/resource/resource_xray_settings_test.go
@@ -113,6 +113,51 @@ func TestAccSettings_basic(t *testing.T) {
 	})
 }
 
+func TestAccSettings_noDbSyncTime(t *testing.T) {
+	_, fqrn, resourceName := testutil.MkNames("test-settings", "xray_settings")
+
+	tmpl := `
+	resource "xray_settings" "{{ .name }}" {
+		enabled                        = true
+		allow_blocked                  = {{ .allowBlocked }}
+		allow_when_unavailable         = {{ .allowWhenUnavailable }}
+		block_unscanned_timeout        = {{ .blockUnscannedTimeout }}
+		block_unfinished_scans_timeout = {{ .blockUnfinishedScansTimeout }}
+	}`
+
+	testData := map[string]any{
+		"name":                        resourceName,
+		"allowBlocked":                testutil.RandBool(),
+		"allowWhenUnavailable":        testutil.RandBool(),
+		"blockUnscannedTimeout":       120,
+		"blockUnfinishedScansTimeout": 3600,
+	}
+
+	config := util.ExecuteTemplate(fqrn, tmpl, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "enabled", "true"),
+					resource.TestCheckResourceAttr(fqrn, "allow_blocked", fmt.Sprintf("%t", testData["allowBlocked"])),
+					resource.TestCheckResourceAttr(fqrn, "allow_when_unavailable", fmt.Sprintf("%t", testData["allowWhenUnavailable"])),
+					resource.TestCheckResourceAttr(fqrn, "block_unscanned_timeout", fmt.Sprintf("%d", testData["blockUnscannedTimeout"])),
+					resource.TestCheckResourceAttr(fqrn, "block_unfinished_scans_timeout", fmt.Sprintf("%d", testData["blockUnfinishedScansTimeout"])),
+					resource.TestCheckResourceAttrSet(fqrn, "db_sync_updates_time"),
+				),
+			},
+			{
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSettings_DbSyncTime(t *testing.T) {
 	_, fqrn, resourceName := testutil.MkNames("db_sync-", "xray_settings")
 	time := "18:45"

--- a/pkg/xray/resource/resource_xray_settings_test.go
+++ b/pkg/xray/resource/resource_xray_settings_test.go
@@ -113,6 +113,7 @@ func TestAccSettings_basic(t *testing.T) {
 	})
 }
 
+// TestAccSettings_noDbSyncTime verifies that omitting the DB sync schedule preserves the server value.
 func TestAccSettings_noDbSyncTime(t *testing.T) {
 	_, fqrn, resourceName := testutil.MkNames("test-settings", "xray_settings")
 
@@ -148,6 +149,14 @@ func TestAccSettings_noDbSyncTime(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "block_unfinished_scans_timeout", fmt.Sprintf("%d", testData["blockUnfinishedScansTimeout"])),
 					resource.TestCheckResourceAttrSet(fqrn, "db_sync_updates_time"),
 				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ResourceName:      fqrn,


### PR DESCRIPTION
## Summary

Changes `db_sync_updates_time` from `Required` to `Optional` + `Computed` so that `xray_settings` can be created without configuring the DB sync schedule. This change makes its behavior consistent with all of the other attributes, which are also 'Optional'.

Ref #421

## Changes

- **Schema**: `db_sync_updates_time` is now `Optional` + `Computed` instead of `Required`.
- **Create/Update**: Added early-exit guards that skip the PUT to `xray/api/v1/configuration/dbsync/time` when `db_sync_updates_time` is null/unknown. In this path, the current server value is read via GET so the `Computed` attribute is populated in state. The resource ID is set to the static string `"settings"`.
- **Read**: No change — always fetches the current DB sync time from the server.
- **Test**: Added `TestAccSettings_noDbSyncTime` acceptance test that creates `xray_settings` without `db_sync_updates_time` and verifies the attribute is populated from the server via `TestCheckResourceAttrSet`, plus import state verification.
- **CHANGELOG**: Added entry for 3.1.12.

## Testing

- `TestAccSettings_noDbSyncTime` — new test covering the omitted `db_sync_updates_time` path (verified: fails without fix, passes with fix)
- `TestAccSettings_basic` — existing test covering the explicit-value path
- `TestAccSettings_DbSyncTime` — existing test covering sync time only
- All three tests pass against a live JFrog Platform instance



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the database sync update time setting optional when configuring Artifactory/Xray integration.
  * When omitted, the existing server value is preserved automatically.
  * Improved state handling and import behavior for configurations without an explicitly provided sync schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->