### PR TITLE
fix: xray_curation_policy: Add block_from_cache argument to prevent silent reset of cache enforcement setting

### DIFF
--- a/docs/resources/curation_policy.md
+++ b/docs/resources/curation_policy.md
@@ -256,6 +256,7 @@ resource "xray_curation_policy" "example_comprehensive" {
 
 ### Optional
 
+- `block_from_cache` (Boolean) When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.
 - `decision_owners` (Set of String) List of JFrog Access groups used by waiver_request_config=manual
 - `label_waivers` (Attributes Set) List of label waivers. (see [below for nested schema](#nestedatt--label_waivers))
 - `notify_emails` (Set of String) List of email addresses that receive notifications when the policy causes a package to be blocked.

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -279,6 +279,7 @@ type CurationPolicyResourceModel struct {
 	NotifyEmails        types.Set    `tfsdk:"notify_emails"`
 	WaiverRequestConfig types.String `tfsdk:"waiver_request_config"`
 	DecisionOwners      types.Set    `tfsdk:"decision_owners"`
+	BlockFromCache      types.Bool   `tfsdk:"block_from_cache"`
 }
 
 type PackageWaiverModel struct {
@@ -321,6 +322,7 @@ type CurationPolicyAPIModel struct {
 	NotifyEmails        []string                `json:"notify_emails,omitempty"`
 	WaiverRequestConfig string                  `json:"waiver_request_config,omitempty"`
 	DecisionOwners      []string                `json:"decision_owners,omitempty"`
+	BlockFromCache      bool                    `json:"block_from_cache,omitempty"`
 }
 
 const (
@@ -457,6 +459,11 @@ func (r *CurationPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "List of JFrog Access groups used by waiver_request_config=manual",
+			},
+			"block_from_cache": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true, the policy also blocks packages served from Artifactory's cache.",
 			},
 		},
 		MarkdownDescription: "Provides an Xray curation policy resource. This resource allows you to create, read, update, and delete curation policies in Xray. See [JFrog Curation REST APIs](https://jfrog.com/help/r/jfrog-rest-apis/create-curation-policy) [Official documentation](https://jfrog.com/help/r/jfrog-security-user-guide/products/curation/configure-curation/create-policies) for more details. \n\n" +
@@ -602,6 +609,11 @@ func (r *CurationPolicyResource) toAPIModel(ctx context.Context, plan CurationPo
 	}
 	// If no label_waivers, leave plan.LabelWaivers as null (don't force empty set)
 
+	// Convert block_from_cache
+	if !plan.BlockFromCache.IsNull() && !plan.BlockFromCache.IsUnknown() {
+		policy.BlockFromCache = plan.BlockFromCache.ValueBool()
+	}
+
 	return nil
 }
 
@@ -612,6 +624,7 @@ func (r *CurationPolicyResource) fromAPIModel(ctx context.Context, policy Curati
 	plan.Scope = types.StringValue(policy.Scope)
 	plan.PolicyAction = types.StringValue(policy.PolicyAction)
 	plan.WaiverRequestConfig = types.StringValue(policy.WaiverRequestConfig)
+	plan.BlockFromCache = types.BoolValue(policy.BlockFromCache)
 
 	// Convert string arrays to sets
 	if len(policy.RepoExclude) > 0 {

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -463,7 +463,7 @@ func (r *CurationPolicyResource) Schema(ctx context.Context, req resource.Schema
 			"block_from_cache": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "When true, the policy also blocks packages served from Artifactory's cache.",
+				Description: "When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.",
 			},
 		},
 		MarkdownDescription: "Provides an Xray curation policy resource. This resource allows you to create, read, update, and delete curation policies in Xray. See [JFrog Curation REST APIs](https://jfrog.com/help/r/jfrog-rest-apis/create-curation-policy) [Official documentation](https://jfrog.com/help/r/jfrog-security-user-guide/products/curation/configure-curation/create-policies) for more details. \n\n" +

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -2646,3 +2646,242 @@ func TestAccCurationPolicy_ComputedRepoInclude(t *testing.T) {
 		},
 	})
 }
+
+// ============================================================================
+// BLOCK FROM CACHE TESTING - Complete coverage of all combinations
+// ============================================================================
+func TestAccCurationPolicy_BlockFromCacheOmitted(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache-omitted", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-omitted-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	// Repository configuration
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create repository first and verify it exists
+				Config: repoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+				),
+			},
+			{
+				// Step 2: Create policy without the block_from_cache attribute, and verify it is false
+				Config: repoConfig +
+					createMaturityCondition(conditionName) + fmt.Sprintf(`
+					resource "xray_curation_policy" "%s" {
+						name                  = "%s"
+						condition_id          = xray_custom_curation_condition.%s.id
+						scope                 = "all_repos"
+						policy_action         = "block"
+						waiver_request_config = "forbidden"
+						notify_emails         = ["audit-team@company.com"]
+					}
+					`, name, name, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "policy_action", "block"),
+					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCurationPolicy_BlockFromCacheFalse(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache-false", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-false-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	// Repository configuration
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create repository first and verify it exists
+				Config: repoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+				),
+			},
+			{
+				// Step 2: Create policy with the block_from_cache attribute set to false, and verify it is false
+				Config: repoConfig +
+					createMaturityCondition(conditionName) + fmt.Sprintf(`
+					resource "xray_curation_policy" "%s" {
+						name                  = "%s"
+						condition_id          = xray_custom_curation_condition.%s.id
+						scope                 = "all_repos"
+						policy_action         = "block"
+						waiver_request_config = "forbidden"
+						block_from_cache      = false
+						notify_emails         = ["audit-team@company.com"]
+					}
+					`, name, name, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "policy_action", "block"),
+					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCurationPolicy_BlockFromCacheTrue(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache-true", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-true-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	// Repository configuration
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create repository first and verify it exists
+				Config: repoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+				),
+			},
+			{
+				// Step 2: Create policy with the block_from_cache attribute set to true, and verify it is true
+				Config: repoConfig +
+					createMaturityCondition(conditionName) + fmt.Sprintf(`
+					resource "xray_curation_policy" "%s" {
+						name                  = "%s"
+						condition_id          = xray_custom_curation_condition.%s.id
+						scope                 = "all_repos"
+						policy_action         = "block"
+						waiver_request_config = "forbidden"
+						block_from_cache      = true
+						notify_emails         = ["audit-team@company.com"]
+					}
+					`, name, name, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "policy_action", "block"),
+					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCurationPolicy_BlockFromCacheTrue_DryRun(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache-true-dry-run", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-true-dry-run-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	// Repository configuration
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create repository first and verify it exists
+				Config: repoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+				),
+			},
+			{
+				// Step 2: Create policy with the block_from_cache attribute set to true, and verify it is true even though policy_action is dry_run
+				Config: repoConfig +
+					createMaturityCondition(conditionName) + fmt.Sprintf(`
+					resource "xray_curation_policy" "%s" {
+						name                  = "%s"
+						condition_id          = xray_custom_curation_condition.%s.id
+						scope                 = "all_repos"
+						policy_action         = "dry_run"
+						waiver_request_config = "forbidden"
+						block_from_cache      = true
+						notify_emails         = ["audit-team@company.com"]
+					}
+					`, name, name, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "policy_action", "dry_run"),
+					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCurationPolicy_BlockFromCache_Toggle(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache-toggle", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-toggle-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	baseConfig := func(blockFromCache string) string {
+		bfc := ""
+		if blockFromCache != "" {
+			bfc = fmt.Sprintf("block_from_cache = %s", blockFromCache)
+		}
+		return repoConfig + createMaturityCondition(conditionName) + fmt.Sprintf(`
+			resource "xray_curation_policy" "%s" {
+				name                  = "%s"
+				condition_id          = xray_custom_curation_condition.%s.id
+				scope                 = "all_repos"
+				policy_action         = "block"
+				waiver_request_config = "forbidden"
+				%s
+			}
+		`, name, name, conditionName, bfc)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create repository first and verify it exists
+				Config: repoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+				),
+			},
+			{
+				// Step 2: Create policy without the block_from_cache attribute, and verify it is false
+				Config: baseConfig(""),
+				Check:  resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+			},
+			{
+				// Step 3: Set block_from_cache to true and verify
+				Config: baseConfig("true"),
+				Check:  resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
+			},
+			{
+				// Step 4: Set block_from_cache back to false and verify
+				Config: baseConfig("false"),
+				Check:  resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+			},
+		},
+	})
+}

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-xray/v3/pkg/acctest"
 )
@@ -2747,6 +2748,18 @@ func TestAccCurationPolicy_BlockFromCacheTrue(t *testing.T) {
 	// Repository configuration
 	repoConfig := createCuratedRepoConfig("npm", repoName)
 
+	policyConfig := repoConfig + createMaturityCondition(conditionName) + fmt.Sprintf(`
+	resource "xray_curation_policy" "%s" {
+		name                  = "%s"
+		condition_id          = xray_custom_curation_condition.%s.id
+		scope                 = "all_repos"
+		policy_action         = "block"
+		waiver_request_config = "forbidden"
+		block_from_cache      = true
+		notify_emails         = ["audit-team@company.com"]
+	}
+	`, name, name, conditionName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -2763,22 +2776,26 @@ func TestAccCurationPolicy_BlockFromCacheTrue(t *testing.T) {
 			},
 			{
 				// Step 2: Create policy with the block_from_cache attribute set to true, and verify it is true
-				Config: repoConfig +
-					createMaturityCondition(conditionName) + fmt.Sprintf(`
-					resource "xray_curation_policy" "%s" {
-						name                  = "%s"
-						condition_id          = xray_custom_curation_condition.%s.id
-						scope                 = "all_repos"
-						policy_action         = "block"
-						waiver_request_config = "forbidden"
-						block_from_cache      = true
-						notify_emails         = ["audit-team@company.com"]
-					}
-					`, name, name, conditionName),
+				Config: policyConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "policy_action", "block"),
 					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
 				),
+			},
+			{
+				// Step 3: Re-apply same config, and verify no drift
+				Config: policyConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// Step 4: Verify import round-trip preserves block_from_cache
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -2784,51 +2784,6 @@ func TestAccCurationPolicy_BlockFromCacheTrue(t *testing.T) {
 	})
 }
 
-func TestAccCurationPolicy_BlockFromCacheTrue_DryRun(t *testing.T) {
-	_, fqrn, name := testutil.MkNames("test-block-from-cache-true-dry-run", "xray_curation_policy")
-	repoName := fmt.Sprintf("block-from-cache-true-dry-run-npm-%d", testutil.RandomInt())
-	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
-
-	// Repository configuration
-	repoConfig := createCuratedRepoConfig("npm", repoName)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		ExternalProviders:        commonExternalProviders,
-		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
-		Steps: []resource.TestStep{
-			{
-				// Step 1: Create repository first and verify it exists
-				Config: repoConfig,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
-					resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
-				),
-			},
-			{
-				// Step 2: Create policy with the block_from_cache attribute set to true, and verify it is true even though policy_action is dry_run
-				Config: repoConfig +
-					createMaturityCondition(conditionName) + fmt.Sprintf(`
-					resource "xray_curation_policy" "%s" {
-						name                  = "%s"
-						condition_id          = xray_custom_curation_condition.%s.id
-						scope                 = "all_repos"
-						policy_action         = "dry_run"
-						waiver_request_config = "forbidden"
-						block_from_cache      = true
-						notify_emails         = ["audit-team@company.com"]
-					}
-					`, name, name, conditionName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "policy_action", "dry_run"),
-					resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccCurationPolicy_BlockFromCache_Toggle(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-block-from-cache-toggle", "xray_curation_policy")
 	repoName := fmt.Sprintf("block-from-cache-toggle-npm-%d", testutil.RandomInt())


### PR DESCRIPTION
Closes #431 

## Problem

The `xray_curation_policy` resource did not include the `block_from_cache` field in its schema. On every PUT, the API received `block_from_cache`: `false` implicitly, silently overwriting whatever the user had configured manually in the Artifactory UI under "Enforce policy on cached packages".

## Root Cause

`CurationPolicyAPIModel` omitted `block_from_cache`, so the field was never read from state or sent to the API. Any update operation reset it to the Go zero value (`false`), regardless of what the server had stored.

## Solution

Added `block_from_cache` as an optional, computed `Bool` attribute on `xray_curation_policy`:

- `toAPIModel` - marshals `block_from_cache` into the PUT request body
- `fromAPIModel` - reads the value back from the API response into state
- Computed so existing resources import cleanly without a forced diff

## Changes

- `pkg/xray/resource/resource_xray_curation_policy.go` - added `BlockFromCache` to `CurationPolicyResourceModel`, `CurationPolicyAPIModel`, schema, `toAPIModel`, and `fromAPIModel`
- `pkg/xray/resource/resource_xray_curation_policy_test.go` - acceptance tests
- `docs/resources/curation_policy.md` - generated docs

## Testing

Added new tests:

- `TestAccCurationPolicy_BlockFromCacheOmitted` - omitting the attribute results in `false`
- `TestAccCurationPolicy_BlockFromCacheFalse` - explicitly setting `false` results in `false`
- `TestAccCurationPolicy_BlockFromCacheTrue` - explicitly setting `true` results in `true`, produces no drift on re-plan, and survives a `terraform import` round-trip
- `TestAccCurationPolicy_BlockFromCache_Toggle` - create without attribute -> update to `true` -> update to `false` all apply cleanly

Testing command:

```bash
export TF_ACC=true
make test
```

## Backward Compatibility

Fully backward compatible. The attribute is `Computed`, so existing state files with no `block_from_cache` entry will read the value from the API on next plan rather than producing a diff.