### PR TITLE
Fix false "Decision owners required" validation error on unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.12 (Jul 23, 2026)
+
+BUG FIXES:
+
+* resource/xray_curation_policy: Fix false `Decision owners required` validation error when `decision_owners` is sourced from another resource, module variable, or other value that is unknown until apply, while `waiver_request_config = "manual"`. The `decisionOwnersRequiredValidator` now skips unknown values and defers validation to the plan phase. Issue: [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)
+
 ## 3.1.11(Jun 9, 2026).
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.12 (Jul 23, 2026)
+## 3.1.12 (Jul 23, 2026). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -45,8 +45,14 @@ func (v decisionOwnersRequiredValidator) ValidateString(ctx context.Context, req
 			return
 		}
 
-		// Check if decision_owners is null, unknown, or empty
-		if decisionOwnersValue.IsNull() || decisionOwnersValue.IsUnknown() {
+		// Skip validation for unknown values (e.g. references to other resources
+		// that aren't resolved until plan/apply); defer to the plan phase.
+		if decisionOwnersValue.IsUnknown() {
+			return
+		}
+
+		// Check if decision_owners is null or empty
+		if decisionOwnersValue.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("decision_owners"),
 				"Decision owners required",

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -2656,6 +2656,7 @@ func TestAccCurationPolicy_ComputedRepoInclude(t *testing.T) {
 func TestAccCurationPolicy_ComputedDecisionOwners(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-computed-owners", "xray_curation_policy")
 	conditionName := fmt.Sprintf("test-computed-owners-condition-%d", testutil.RandomInt())
+	repoName := fmt.Sprintf("computed-owners-repo-%d", testutil.RandomInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -2665,6 +2666,13 @@ func TestAccCurationPolicy_ComputedDecisionOwners(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: createCVSSCondition(conditionName) + fmt.Sprintf(`
+					resource "artifactory_remote_npm_repository" "repo" {
+						key             = "%s"
+						url             = "https://registry.npmjs.org/"
+						repo_layout_ref = "npm-default"
+						curated         = true
+					}
+
 					# output is computed, so decision_owners is unknown at plan time
 					resource "terraform_data" "owners" {
 						input = ["readers"]
@@ -2673,15 +2681,16 @@ func TestAccCurationPolicy_ComputedDecisionOwners(t *testing.T) {
 					resource "xray_curation_policy" "%s" {
 						name                  = "%s"
 						condition_id          = xray_custom_curation_condition.%s.id
-						scope                 = "all_repos"
+						scope                 = "specific_repos"
+						repo_include          = [artifactory_remote_npm_repository.repo.key]
 						policy_action         = "block"
 						waiver_request_config = "manual"
 						decision_owners       = terraform_data.owners.output
 					}
-				`, name, name, conditionName),
+				`, repoName, name, name, conditionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", name),
-					resource.TestCheckResourceAttr(fqrn, "scope", "all_repos"),
+					resource.TestCheckResourceAttr(fqrn, "scope", "specific_repos"),
 					resource.TestCheckResourceAttr(fqrn, "waiver_request_config", "manual"),
 					resource.TestCheckResourceAttr(fqrn, "decision_owners.#", "1"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "decision_owners.*", "readers"),

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -2646,3 +2646,47 @@ func TestAccCurationPolicy_ComputedRepoInclude(t *testing.T) {
 		},
 	})
 }
+
+// When decision_owners is sourced from
+// another resource (so the whole set is unknown until apply), the
+// decisionOwnersRequiredValidator used to raise a false "Decision owners
+// required" error during plan instead of deferring validation. Here
+// decision_owners is fed from terraform_data.owners.output, whose value is
+// unknown at plan time; the validator must skip it and let apply resolve it.
+func TestAccCurationPolicy_ComputedDecisionOwners(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-computed-owners", "xray_curation_policy")
+	conditionName := fmt.Sprintf("test-computed-owners-condition-%d", testutil.RandomInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				Config: createCVSSCondition(conditionName) + fmt.Sprintf(`
+					# output is computed, so decision_owners is unknown at plan time
+					resource "terraform_data" "owners" {
+						input = ["readers"]
+					}
+
+					resource "xray_curation_policy" "%s" {
+						name                  = "%s"
+						condition_id          = xray_custom_curation_condition.%s.id
+						scope                 = "all_repos"
+						policy_action         = "block"
+						waiver_request_config = "manual"
+						decision_owners       = terraform_data.owners.output
+					}
+				`, name, name, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", name),
+					resource.TestCheckResourceAttr(fqrn, "scope", "all_repos"),
+					resource.TestCheckResourceAttr(fqrn, "waiver_request_config", "manual"),
+					resource.TestCheckResourceAttr(fqrn, "decision_owners.#", "1"),
+					resource.TestCheckTypeSetElemAttr(fqrn, "decision_owners.*", "readers"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Fix false "Decision owners required" validation error on unknown values

Fixes [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)

## Problem

On `resource/xray_curation_policy`, the `decisionOwnersRequiredValidator` enforces
that `decision_owners` is provided when `waiver_request_config = "manual"`.

The validator treated an **unknown** value the same as a **null/empty** one:

```go
if decisionOwnersValue.IsNull() || decisionOwnersValue.IsUnknown() {
    // error: "Decision owners required"
}
```

In Terraform, a value that references another resource, a module variable, or a
computed collection is *unknown* during `validate`/`plan` — the real value only
exists at apply time. The framework contract is that validators must skip unknown
values and defer to the plan phase. Because this validator didn't, any config
where the whole `decision_owners` set is unknown failed with a false positive:

```
Error: Decision owners required
  Decision owners are required when waiver requests are manually approved
  (waiver_request_config = 'manual')
```

The sibling validators in the same file (`packageVersionsRequiredValidator`,
`scopeRequirementsValidator`) already skip unknown values correctly — this one
was simply missing that guard.

## Fix

Separate the unknown case from the null/empty case: return early on unknown, and
only raise the error when the value is genuinely null or an empty set.

```go
// Skip validation for unknown values (e.g. references to other resources
// that aren't resolved until plan/apply); defer to the plan phase.
if decisionOwnersValue.IsUnknown() {
    return
}

// Check if decision_owners is null or empty
if decisionOwnersValue.IsNull() {
    ...
}
```

## Reproduction & verification

Reproduced end-to-end with a locally-built provider (dev override) against a live
JFrog Platform:

| Scenario | Before fix | After fix |
| --- | --- | --- |
| `manual` + `decision_owners = terraform_data.grp.output` (whole set unknown) | ❌ `Error: Decision owners required` (false positive) | ✅ validates, defers to apply |
| `manual` + `decision_owners` omitted entirely | ❌ errors (correct) | ❌ still errors (correct) |
| `manual` + `decision_owners = ["readers"]` | ✅ | ✅ |

The fix defers the unknown case while preserving the genuine null/empty check.

## Tests

Added `TestAccCurationPolicy_ComputedDecisionOwners`, mirroring the existing
`TestAccCurationPolicy_ComputedRepoInclude` regression test for the sibling
validator. It sets `waiver_request_config = "manual"` and sources
`decision_owners` from a value that is unknown at plan time, asserting the plan
no longer errors and resolves to the expected group at apply. This test fails
before the fix and passes after.

## Changelog

Added a `3.1.12` BUG FIXES entry.
