### PR TITLE
Fix hard-coded `condition_template_id` allow-list rejecting valid platform templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.12 (Jul 23,2026)
+
+BUG FIXES:
+
+* resource/xray_custom_curation_condition: Remove the hard-coded `condition_template_id` allow-list that rejected valid platform-supported templates (e.g. `isMalicious`, `NoLicense`, aged-package variants) before the request reached the API. The set of available templates depends on the JFrog Platform version and enabled features, so `condition_template_id` is no longer restricted client-side and parameter validation is deferred to the Xray API for templates the provider does not recognize. Issue: [#432](https://github.com/jfrog/terraform-provider-xray/issues/432)
+
 ## 3.1.11(Jun 9, 2026).
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.12 (Jul 23,2026). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1) with Terraform 1.15.8 and OpenTofu 1.12.5
+## 3.1.12 (Jul 23,2026). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.12 (Jul 23,2026)
+## 3.1.12 (Jul 23,2026). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_xray_custom_curation_condition.go
+++ b/pkg/xray/resource/resource_xray_custom_curation_condition.go
@@ -100,7 +100,18 @@ func (v paramValuesJSONValidator) ValidateString(ctx context.Context, req valida
 		}
 	}
 
-	// Check for empty parameters (required for all templates)
+	// For templates the provider doesn't know about (e.g. platform/version-specific
+	// templates such as isMalicious, NoLicense, or aged-package variants), defer
+	// parameter validation to the Xray API, which is the source of truth for both
+	// the allowed template IDs and their parameters. The JSON syntax has already
+	// been validated above.
+	if conditionTemplateID != "" {
+		if _, known := conditionTemplateParams[conditionTemplateID]; !known {
+			return
+		}
+	}
+
+	// Check for empty parameters (required for all known templates)
 	if len(paramValues) == 0 {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
@@ -1105,21 +1116,13 @@ func (r *CustomCurationConditionResource) Schema(ctx context.Context, req resour
 				},
 			},
 			"condition_template_id": schema.StringAttribute{
-				Required:    true,
-				Description: "One of the IDs of the supported condition templates returned by the list condition templates API.",
+				Required: true,
+				Description: "One of the IDs of the supported condition templates returned by the list condition templates API. " +
+					"The set of available templates depends on the JFrog Platform version and enabled features " +
+					"(e.g. `isMalicious`, `NoLicense`, aged-package variants), so the value is not restricted to a " +
+					"fixed list client-side; unsupported templates are rejected by the Xray API.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
-					stringvalidator.OneOf(
-						"OpenSSF",
-						"BannedLabels",
-						"AllowedLabels",
-						"SpecificVersions",
-						"AllowedLicenses",
-						"BannedLicenses",
-						"CVECVSSRange",
-						"isImmature",
-						"CVEName",
-					),
 				},
 			},
 			"param_values": schema.StringAttribute{

--- a/pkg/xray/resource/resource_xray_custom_curation_condition_test.go
+++ b/pkg/xray/resource/resource_xray_custom_curation_condition_test.go
@@ -29,6 +29,34 @@ func TestAccCustomCurationCondition_CVEName_Smoke(t *testing.T) {
 	})
 }
 
+// TestAccCustomCurationCondition_PlatformSpecificTemplate_NotRejectedClientSide is a
+// regression test for https://github.com/jfrog/terraform-provider-xray/issues/432
+//
+// The provider previously restricted condition_template_id to a hard-coded OneOf list,
+// rejecting valid platform/version-specific templates (e.g. isMalicious, NoLicense,
+// aged-package variants) at plan time before the request ever reached the Xray API.
+// The set of supported templates is dynamic (returned by the condition_templates API),
+// so the provider must not gate it client-side.
+//
+// This uses PlanOnly so it exercises the config-level validators without requiring the
+// backend to actually support the template. Before the fix the plan fails with
+// "Invalid Attribute Value Match"; after the fix the config plans successfully.
+func TestAccCustomCurationCondition_PlatformSpecificTemplate_NotRejectedClientSide(t *testing.T) {
+	_, _, name := testutil.MkNames("test-platform-template", "xray_custom_curation_condition")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccCustomCurationConditionPlatformTemplate(name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // CVEName Tests
 func TestAccCustomCurationCondition_CVEName_Basic(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-cve-condition", "xray_custom_curation_condition")
@@ -436,6 +464,21 @@ resource "xray_custom_curation_condition" "{{ .name }}" {
       value    = "CVE-2021-45105"
     }
   ])
+}
+`, map[string]interface{}{
+		"name": name,
+	})
+}
+
+// testAccCustomCurationConditionPlatformTemplate uses a template ID that is not in the
+// provider's previously hard-coded list, to verify it is no longer rejected client-side.
+func testAccCustomCurationConditionPlatformTemplate(name string) string {
+	return util.ExecuteTemplate("TestAccCustomCurationConditionPlatformTemplate", `
+resource "xray_custom_curation_condition" "{{ .name }}" {
+  name                 = "{{ .name }}"
+  condition_template_id = "isMalicious"
+
+  param_values = jsonencode([])
 }
 `, map[string]interface{}{
 		"name": name,


### PR DESCRIPTION
# Fix hard-coded `condition_template_id` allow-list rejecting valid platform templates

Fixes [#432](https://github.com/jfrog/terraform-provider-xray/issues/432)

## Problem

`resource/xray_custom_curation_condition` restricted `condition_template_id` to a
hard-coded `stringvalidator.OneOf(...)` of 9 template IDs. The set of templates
Xray actually supports is **dynamic** — it is returned by the
`GET xray/api/v1/curation/condition_templates` API and varies by JFrog Platform
version and enabled features (e.g. malicious-package detection).

As a result, valid platform templates such as `isMalicious`, `NoLicense`, and
aged-package variants were rejected by the provider at `terraform validate`/`plan`
time, before the request ever reached the API:

```
Error: Invalid Attribute Value Match
condition_template_id value must be one of: ["OpenSSF" "BannedLabels"
"AllowedLabels" "SpecificVersions" "AllowedLicenses" "BannedLicenses"
"CVECVSSRange" "isImmature" "CVEName"], got: "isMalicious"
```

The schema description itself already stated the value is "One of the IDs of the
supported condition templates returned by the list condition templates API" — but
the validator contradicted that by baking in a static list.

## Fix

1. **Removed the hard-coded `OneOf`** on `condition_template_id` (kept
   `LengthAtLeast(1)`). The Xray API is the source of truth and returns a clear
   `Unknown ConditionTemplateId '<id>'` error for genuinely invalid IDs.
2. **Deferred parameter validation to the API for unrecognized templates.** The
   `param_values` validator still fully validates templates the provider knows
   about (param names, counts, required params, value types), but for any template
   not in its internal map it now validates only JSON syntax and defers the rest to
   the API — so new/platform-specific templates aren't blocked by provider-side
   param rules.
3. Updated the schema description to explain the value is not restricted
   client-side.

## Reproduction & verification

Reproduced with a locally-built provider (dev override):

| Scenario | Before fix | After fix |
| --- | --- | --- |
| `condition_template_id = "isMalicious"` | ❌ `Invalid Attribute Value Match` at `validate` | ✅ provider validates; deferred to API |
| Known template (`CVEName`) + valid params | ✅ | ✅ |
| Known template (`CVEName`) + invalid `param_id` | ❌ errors (correct) | ❌ still errors (correct) |

On the test platform (Xray 3.143.30) the `condition_templates` API returns only
the original 9 templates and rejects `isMalicious` with
`Unknown ConditionTemplateId 'isMalicious'` — confirming the template set is
platform-dependent and that the API correctly gatekeeps invalid IDs once the
client-side block is removed.

## Tests

Added `TestAccCustomCurationCondition_PlatformSpecificTemplate_NotRejectedClientSide`.
It uses a `PlanOnly` step with `condition_template_id = "isMalicious"`, so it
exercises the config-level validators (where the `OneOf` lived) without requiring
the backend to support the template. It fails before the fix
(`Invalid Attribute Value Match`) and passes after. Existing acceptance tests for
the known templates continue to validate parameters exactly as before.

## Changelog

Added a `3.1.12` BUG FIXES entry.
