### PR TITLE
JTFPR-315 - Fix GCE Persistent Disk leak in acceptance-tests workflow

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -288,6 +288,23 @@ jobs:
           install-only: true
       - name: Execute acceptance tests
         run: make acceptance -e TARGET_ARCH=linux_amd64
+      - name: Cleanup Kubernetes persistent volumes
+        # Runs BEFORE cluster delete so the PD CSI driver can cascade
+        # PVC delete → PV delete → GCE Persistent Disk delete while the
+        # cluster is still alive. gcloud container clusters delete does
+        # NOT delete dynamically-provisioned PDs on its own, so skipping
+        # this step leaks ~650 GiB of orphaned disks per run.
+        if: always() && steps.install_platform.conclusion == 'success'
+        continue-on-error: true
+        run: |
+          echo "Uninstalling jfrog-platform Helm release..."
+          helm uninstall jfrog-platform --wait --timeout 5m --ignore-not-found || true
+          echo "Deleting any remaining PVCs (belt-and-braces)..."
+          kubectl delete pvc --all --all-namespaces --wait=true --timeout=5m --ignore-not-found || true
+          # Give the PD CSI driver a moment to complete delete-disk calls.
+          sleep 20
+          echo "Remaining PVs (should be empty):"
+          kubectl get pv 2>/dev/null || true
       - name: Install provider
         run: |
           export PROVIDER_VERSION=$(git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')


### PR DESCRIPTION
## Summary

Every run of `acceptance-tests.yml` leaks **~650 GiB of GCE Persistent Disks** into the GCP project. Multiplied by the terraform + tofu matrix and every PR / dispatch, it adds up fast.

## Root cause

The workflow provisions PVs through Helm on GKE:

```
postgres.primary       500 GiB   (--set postgresql.primary.persistence.size=500Gi)
artifactory            50 GiB    (--set artifactory.artifactory.persistence.size=50Gi)
xray (chart default)   ~50–100 GiB
rabbitmq (chart)       ~10 GiB
```

…but the only cleanup at the end is `gcloud container clusters delete`. That command does **not** delete dynamically-provisioned Persistent Disks — the PD CSI driver only issues the delete-disk API call when a **PVC is deleted while the cluster is still alive**, so the StorageClass `reclaimPolicy: Delete` can cascade PVC → PV → GCE PD delete.

When you go straight to `clusters delete`:
1. Nodes get destroyed → PDs get detached (users=[])
2. Control plane goes away → CSI driver is gone
3. The disks are now unrecoverable orphans in GCP

`fail-fast: true` on the matrix compounds it: when `terraform` fails, `tofu` gets cancelled mid-run and cleanup steps may not fire at all.

## Fix

Insert a `Cleanup Kubernetes persistent volumes` step between `Execute acceptance tests` and `Delete GKE cluster`:

```yaml
- name: Cleanup Kubernetes persistent volumes
  if: always() && steps.install_platform.conclusion == 'success'
  continue-on-error: true
  run: |
    helm uninstall jfrog-platform --wait --timeout 5m --ignore-not-found || true
    kubectl delete pvc --all --all-namespaces --wait=true --timeout=5m --ignore-not-found || true
    sleep 20
    kubectl get pv 2>/dev/null || true
```

- **Runs before cluster delete** so the CSI driver is still alive to process PD deletions.
- **`continue-on-error: true`** — cleanup failure never blocks the subsequent cluster delete. If helm hangs, cluster delete still fires and at least the nodes go away.
- **`if: always() && steps.install_platform.conclusion == 'success'`** — skip on runs where the platform never got installed (no PVCs to delete).

## Test plan

- [ ] After merge, run a PR-triggered `acceptance-tests` workflow and verify:
  - Cleanup step logs show `release "jfrog-platform" uninstalled` and empty PV list.
  - `gcloud compute disks list --filter="zone:${GKE_ZONE} AND -users:*" --project ${GKE_PROJECT}` shows no new orphan `pvc-*` disks after the run.
- [ ] Do an audit: `gcloud compute disks list --filter="name ~ pvc-.* AND -users:*"` — one-time cleanup of the accumulated orphans.

JIRA: [JTFPR-315](https://jfrog-int.atlassian.net/browse/JTFPR-315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)