### PR TITLE
JTFPR-431: Add block_from_cache to xray_curation_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 3.1.12 (Jul 23, 2026). Tested on JFrog Platform 11.5.11 (Artifactory 7.146.29, Xray 3.143.31, Catalog 1.43.1) with Terraform 1.15.8 and OpenTofu 1.12.5
+## 3.1.12 (Jul 31, 2026). 
 
 BUG FIXES:
 
 * resource/xray_curation_policy: Fix false `Decision owners required` validation error when `decision_owners` is sourced from another resource, module variable, or other value that is unknown until apply, while `waiver_request_config = "manual"`. The `decisionOwnersRequiredValidator` now skips unknown values and defers validation to the plan phase. Issue: [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)
+
+* resource/xray_curation_policy: Add `block_from_cache` attribute so the "Enforce policy on cached packages" setting is read from and written to the API instead of being silently reset to `false` on every update. Issue: [#431](https://github.com/jfrog/terraform-provider-xray/issues/431) PR: [#435](https://github.com/jfrog/terraform-provider-xray/pull/435)
 
 ## 3.1.11(Jun 9, 2026).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.12 (Jul 31, 2026). 
+## 3.1.12 (Jul 31, 2026). Tested on JFrog Platform 11.6.0 (Artifactory 7.161.15, Xray 3.150.17, Catalog 1.43.2) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/docs/resources/curation_policy.md
+++ b/docs/resources/curation_policy.md
@@ -256,6 +256,7 @@ resource "xray_curation_policy" "example_comprehensive" {
 
 ### Optional
 
+- `block_from_cache` (Boolean) When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.
 - `decision_owners` (Set of String) List of JFrog Access groups used by waiver_request_config=manual
 - `label_waivers` (Attributes Set) List of label waivers. (see [below for nested schema](#nestedatt--label_waivers))
 - `notify_emails` (Set of String) List of email addresses that receive notifications when the policy causes a package to be blocked.

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -285,6 +285,7 @@ type CurationPolicyResourceModel struct {
 	NotifyEmails        types.Set    `tfsdk:"notify_emails"`
 	WaiverRequestConfig types.String `tfsdk:"waiver_request_config"`
 	DecisionOwners      types.Set    `tfsdk:"decision_owners"`
+	BlockFromCache      types.Bool   `tfsdk:"block_from_cache"`
 }
 
 type PackageWaiverModel struct {
@@ -327,6 +328,7 @@ type CurationPolicyAPIModel struct {
 	NotifyEmails        []string                `json:"notify_emails,omitempty"`
 	WaiverRequestConfig string                  `json:"waiver_request_config,omitempty"`
 	DecisionOwners      []string                `json:"decision_owners,omitempty"`
+	BlockFromCache      bool                    `json:"block_from_cache"`
 }
 
 const (
@@ -463,6 +465,11 @@ func (r *CurationPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "List of JFrog Access groups used by waiver_request_config=manual",
+			},
+			"block_from_cache": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.",
 			},
 		},
 		MarkdownDescription: "Provides an Xray curation policy resource. This resource allows you to create, read, update, and delete curation policies in Xray. See [JFrog Curation REST APIs](https://jfrog.com/help/r/jfrog-rest-apis/create-curation-policy) [Official documentation](https://jfrog.com/help/r/jfrog-security-user-guide/products/curation/configure-curation/create-policies) for more details. \n\n" +
@@ -608,6 +615,11 @@ func (r *CurationPolicyResource) toAPIModel(ctx context.Context, plan CurationPo
 	}
 	// If no label_waivers, leave plan.LabelWaivers as null (don't force empty set)
 
+	// Convert block_from_cache
+	if !plan.BlockFromCache.IsNull() && !plan.BlockFromCache.IsUnknown() {
+		policy.BlockFromCache = plan.BlockFromCache.ValueBool()
+	}
+
 	return nil
 }
 
@@ -618,6 +630,7 @@ func (r *CurationPolicyResource) fromAPIModel(ctx context.Context, policy Curati
 	plan.Scope = types.StringValue(policy.Scope)
 	plan.PolicyAction = types.StringValue(policy.PolicyAction)
 	plan.WaiverRequestConfig = types.StringValue(policy.WaiverRequestConfig)
+	plan.BlockFromCache = types.BoolValue(policy.BlockFromCache)
 
 	// Convert string arrays to sets
 	if len(policy.RepoExclude) > 0 {

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-xray/v3/pkg/acctest"
 )
@@ -2697,5 +2698,90 @@ func TestAccCurationPolicy_ComputedDecisionOwners(t *testing.T) {
 				),
 			},
 		},
+	})
+}
+
+// block_from_cache = true requires the platform-level "Enable Curation for Cached
+// Packages" feature (backed by a Valkey cache), which is absent on most environments
+// and cannot be toggled via a public API. Without it the Xray API rejects the policy
+// with "block from cache is not enabled in curation config", so the steps that set it
+// to true only run when XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED is set.
+func TestAccCurationPolicy_BlockFromCache(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-block-from-cache", "xray_curation_policy")
+	repoName := fmt.Sprintf("block-from-cache-npm-%d", testutil.RandomInt())
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	repoConfig := createCuratedRepoConfig("npm", repoName)
+
+	policyConfig := func(blockFromCache string) string {
+		bfc := ""
+		if blockFromCache != "" {
+			bfc = fmt.Sprintf("block_from_cache = %s", blockFromCache)
+		}
+		return repoConfig + createMaturityCondition(conditionName) + fmt.Sprintf(`
+			resource "xray_curation_policy" "%s" {
+				name                  = "%s"
+				condition_id          = xray_custom_curation_condition.%s.id
+				scope                 = "all_repos"
+				policy_action         = "block"
+				waiver_request_config = "forbidden"
+				notify_emails         = ["audit-team@company.com"]
+				%s
+			}
+		`, name, name, conditionName, bfc)
+	}
+
+	steps := []resource.TestStep{
+		{
+			// Create the curated repository before the policy references it
+			Config: repoConfig,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "key", repoName),
+				resource.TestCheckResourceAttr(fmt.Sprintf("artifactory_remote_npm_repository.%s", repoName), "curated", "true"),
+			),
+		},
+		{
+			// Omitting the attribute defaults it to false
+			Config: policyConfig(""),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(fqrn, "policy_action", "block"),
+				resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+			),
+		},
+	}
+
+	if os.Getenv("XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED") != "" {
+		steps = append(steps,
+			resource.TestStep{
+				Config: policyConfig("true"),
+				Check:  resource.TestCheckResourceAttr(fqrn, "block_from_cache", "true"),
+			},
+			resource.TestStep{
+				// Updating the policy must not silently reset the flag
+				Config: policyConfig("true"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			resource.TestStep{
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: policyConfig("false"),
+				Check:  resource.TestCheckResourceAttr(fqrn, "block_from_cache", "false"),
+			},
+		)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps:                    steps,
 	})
 }


### PR DESCRIPTION
Closes #431. 
Original external PR: #435 (from fork `Tyler-Walker-Zywave:feat/xray-policy-cache-enforcement`, mirrored here so CI can run).

## What this adds

`block_from_cache` (Optional + Computed Bool) on `xray_curation_policy`, so the "Enforce policy on cached packages" setting is read from and written to the API instead of being silently reset to `false` on every update.

The API struct uses `json:"block_from_cache"` without `omitempty`, so an explicit `false` is always serialized rather than relying on the API treating an absent field as `false`. 

## Testing

A single acceptance test, `TestAccCurationPolicy_BlockFromCache`, replaces the four separate tests the original PR added. Steps that always run: create the curated repository, then create a policy with the attribute omitted and assert it defaults to `false`. Passing locally against a live JFrog Platform:

```
--- PASS: TestAccCurationPolicy_BlockFromCache (23.66s)
```

Steps that set `block_from_cache = true` are appended to the same test only when `XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED` is set: set to true, assert an empty plan on re-apply (the actual regression), import round-trip, then back to false. On a platform without the feature those steps are simply not in the step list, so the test passes rather than failing or reporting a skip.
