### PR TITLE
Fix perpetual paths_config diff when pattern.exclude is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 3.1.12 (Jul 31, 2026). Tested on JFrog Platform 11.6.0 (Artifactory 7.161.15, Xray 3.150.17, Catalog 1.43.2) with Terraform 1.15.8 and OpenTofu 1.12.5
+## 3.1.12 (Jul 31, 2026). 
 
 BUG FIXES:
+
+* resource/xray_repository_config: Fix perpetual diff on the `paths_config` block when `pattern.exclude` is not set. The API returns an empty string for an unset exclusion, which was stored in state as an empty string instead of null, so every `terraform plan` showed the whole `paths_config` block being removed and re-added.
 
 * resource/xray_curation_policy: Fix false `Decision owners required` validation error when `decision_owners` is sourced from another resource, module variable, or other value that is unknown until apply, while `waiver_request_config = "manual"`. The `decisionOwnersRequiredValidator` now skips unknown values and defers validation to the plan phase. Issue: [#433](https://github.com/jfrog/terraform-provider-xray/issues/433)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.12 (Jul 31, 2026). 
+## 3.1.12 (Jul 31, 2026). Tested on JFrog Platform 11.6.0 (Artifactory 7.161.15, Xray 3.150.19, Catalog 1.43.3) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/pkg/xray/resource/resource_xray_repository_config.go
+++ b/pkg/xray/resource/resource_xray_repository_config.go
@@ -371,11 +371,19 @@ func (m *RepoConfigResourceModel) fromAPIModel(_ context.Context, xrayVersion, p
 		patterns := lo.Map(
 			apiModel.RepoPathsConfig.Patterns,
 			func(pattern PatternAPIModel, _ int) attr.Value {
+				// The API always returns 'exclude' and uses an empty string when no exclusion
+				// is set. 'exclude' is optional and cannot be set to an empty string, so it
+				// must map back to null to avoid a perpetual diff when it is omitted.
+				exclude := types.StringNull()
+				if pattern.Exclude != "" {
+					exclude = types.StringValue(pattern.Exclude)
+				}
+
 				p, d := types.ObjectValue(
 					pathsConfigPatternResourceModelAttributeTypes,
 					map[string]attr.Value{
 						"include":             types.StringValue(pattern.Include),
-						"exclude":             types.StringValue(pattern.Exclude),
+						"exclude":             exclude,
 						"index_new_artifacts": types.BoolValue(pattern.IndexNewArtifacts),
 						"retention_in_days":   types.Int64Value(pattern.RetentionInDays),
 					},

--- a/pkg/xray/resource/resource_xray_repository_config_test.go
+++ b/pkg/xray/resource/resource_xray_repository_config_test.go
@@ -752,6 +752,61 @@ func TestAccRepositoryConfig_RepoPathsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccRepositoryConfig_RepoPathsNoExclude(t *testing.T) {
+	jasDisabled := os.Getenv("JFROG_JAS_DISABLED")
+	if strings.ToLower(jasDisabled) == "true" {
+		t.Skipf("Env var JFROG_JAS_DISABLED is set to 'true'")
+	}
+
+	_, fqrn, resourceName := testutil.MkNames("xray-repo-config-", "xray_repository_config")
+	_, _, repoName := testutil.MkNames("generic-local", "artifactory_local_generic_repository")
+
+	var testData = map[string]string{
+		"resource_name":                resourceName,
+		"repo_name":                    repoName,
+		"package_type":                 "generic",
+		"pattern0_include":             "core/**",
+		"pattern0_index_new_artifacts": "true",
+		"pattern0_retention_in_days":   "45",
+		"other_index_new_artifacts":    "true",
+		"other_retention_in_days":      "60",
+	}
+
+	config := util.ExecuteTemplate(fqrn, TestDataRepoPathsConfigNoExcludeTemplate, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"artifactory": {
+				Source:            "jfrog/artifactory",
+				VersionConstraint: "12.9.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "paths_config.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "paths_config.0.pattern.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(fqrn, "paths_config.0.pattern.*", map[string]string{
+						"include":             testData["pattern0_include"],
+						"index_new_artifacts": testData["pattern0_index_new_artifacts"],
+						"retention_in_days":   testData["pattern0_retention_in_days"],
+					}),
+				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func verifyRepositoryConfig(fqrn string, testData map[string]string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(fqrn, "repo_name", testData["repo_name"]),
@@ -1110,6 +1165,38 @@ resource "xray_repository_config" "{{ .resource_name }}" {
       exclude             = "{{ .pattern1_exclude }}"
       index_new_artifacts = {{ .pattern1_index_new_artifacts }}
       retention_in_days   = {{ .pattern1_retention_in_days }}
+    }
+
+    all_other_artifacts {
+      index_new_artifacts = {{ .other_index_new_artifacts }}
+      retention_in_days   = {{ .other_retention_in_days }}
+    }
+  }
+}`
+
+const TestDataRepoPathsConfigNoExcludeTemplate = `
+resource "artifactory_local_{{ .package_type }}_repository" "{{ .repo_name }}" {
+	key        = "{{ .repo_name }}"
+	xray_index = true
+}
+
+resource "xray_repository_config" "{{ .resource_name }}" {
+  repo_name   = artifactory_local_{{ .package_type }}_repository.{{ .repo_name }}.key
+  jas_enabled = true
+
+  config {
+    exposures {
+      scanners_category {
+        secrets = true
+      }
+    }
+  }
+
+  paths_config {
+    pattern {
+      include             = "{{ .pattern0_include }}"
+      index_new_artifacts = {{ .pattern0_index_new_artifacts }}
+      retention_in_days   = {{ .pattern0_retention_in_days }}
     }
 
     all_other_artifacts {


### PR DESCRIPTION
## Summary

- Fixes a perpetual Terraform plan diff on `xray_repository_config.paths_config` when `pattern.exclude` is omitted.
- Maps an empty `exclude` string returned by the Xray API back to `null` during refresh so state matches an omitted attribute.
- Adds an acceptance test that applies a `paths_config` pattern without `exclude` and asserts an empty plan on the next run.

## Problem

Customers saw the entire `paths_config` block reported as removed and re-added on every `terraform plan`, even when the Terraform configuration had not changed. Applying the plan made no real change in Xray, and the same diff reappeared on the next plan.

The noise made it hard to spot real configuration changes.

## Root Cause

`paths_config.pattern.exclude` is optional. When it is omitted, Terraform treats the value as `null`.

The Xray API always returns `exclude` as a string and uses `""` when no exclusion is set. On refresh, the provider stored that empty string in state. Terraform then compared:

- config / plan: `exclude = null` (omitted)
- refreshed state: `exclude = ""`

Those are not equal, so every plan reported a change. Because `pattern` is a set nested block, changing one attribute changes the set element identity, so Terraform rendered the whole `paths_config` block as removed and re-added.

Workaround observed by support: setting `exclude = "*"` avoided the diff. `exclude = ""` is rejected by `LengthAtLeast(1)`, and `exclude = null` is equivalent to omitting the attribute, so neither helped.

## Solution

In `fromAPIModel`, treat an empty API `exclude` value as null:

```go
exclude := types.StringNull()
if pattern.Exclude != "" {
    exclude = types.StringValue(pattern.Exclude)
}
```

This is safe because the schema already rejects empty-string `exclude` values in configuration. An empty string from the API can only mean "unset".

No schema change and no state upgrade are required. `toAPIModel` already sends `""` for a null `exclude` via `ValueString()`.

## Changes

- `pkg/xray/resource/resource_xray_repository_config.go` — normalize empty API `exclude` to null on read
- `pkg/xray/resource/resource_xray_repository_config_test.go` — add `TestAccRepositoryConfig_RepoPathsNoExclude`
- `CHANGELOG.md` — document the bug fix under 3.1.12

## Testing

Added:

- `TestAccRepositoryConfig_RepoPathsNoExclude` — creates `paths_config` with `exclude` omitted, then re-plans the same config with `plancheck.ExpectEmptyPlan()`

Verified against a live JPD:

```bash
set -a && source .env && set +a
TF_ACC=1 go test -run 'TestAccRepositoryConfig_RepoPathsNoExclude' -count=1 -v -timeout 20m ./pkg/xray/resource/
```

Result: `PASS`

## Backward Compatibility

Fully backward compatible. Configurations that already set a non-empty `exclude` are unchanged. Configurations that omit `exclude` stop producing a false perpetual diff after upgrade; no state migration is needed.
