### PR TITLE
JTFPR-262 - Add a build-gate so customer fork PRs can run acceptance …

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,118 @@
+# CI: Build Gate (JTFPR-262)
+
+This branch (`feature/JTFPR-262`) changes how GitHub Actions runs on **customer / fork pull requests**.
+
+Ticket: [JTFPR-262](https://jfrog-int.atlassian.net/browse/JTFPR-262)  
+Pattern: [jfrog/jfrog-cli build-gate](https://github.com/jfrog/jfrog-cli/blob/master/.github/workflows/build-gate.yml)
+
+## Problem we are fixing
+
+This repo is public. Customer PRs come from **forks**. The old workflow used `on: pull_request` and `environment: development`.
+
+On a public fork that combination:
+
+1. Never injects GKE / license / Slack secrets
+2. Often sits on “Approve and run workflows” or environment rejection
+3. Never reaches `make acceptance`
+4. Even if tests ran, `update-changelog` could not `git push` to the customer’s branch
+
+The workaround was to copy the customer’s commits onto a same-repo branch and open an internal PR.
+
+## What this branch does
+
+Same idea as jfrog-cli: **one maintainer approval**, then tests run in the **base repo** context so secrets exist.
+
+```
+Customer PR (fork)
+        │
+        ▼
+pull_request_target  ── workflow YAML always from our `main`, never from the fork
+        │
+        ▼
+gate job  ── waits on GitHub environment `build-gate` (required reviewers)
+        │
+        ▼  (only after approval)
+acceptance tests  ── checkout PR SHA, secrets: inherit, persist-credentials: false
+        │
+        ▼
+build-gate-success  ── single required status check
+```
+
+| Change | File |
+|---|---|
+| New orchestrator | [`build-gate.yml`](build-gate.yml) |
+| Tests are reusable only (`workflow_call`) | [`acceptance-tests.yml`](acceptance-tests.yml) |
+| Checkout customer SHA after the gate; no git write token on that tree | `persist-credentials: false` |
+| Changelog `git push` only for same-repo PRs | `update-changelog` job |
+
+Do **not** add `pull_request`, ungated `pull_request_target`, or `workflow_dispatch` back onto `acceptance-tests.yml`. That either withholds secrets or runs untrusted code with secrets and no approval.
+
+## Secrets are not given to the customer PR automatically
+
+| Layer | What it does |
+|---|---|
+| `pull_request_target` | Uses the workflow on `main`. A fork cannot change the gate. |
+| Environment `build-gate` | Test jobs do not start (and do not receive secrets) until a maintainer approves. |
+| `secrets: inherit` | Passed only to jobs that `need: gate`. |
+| `persist-credentials: false` | Customer tree does not keep a `GITHUB_TOKEN` for `git push`. |
+| No changelog push to forks | We never write to the customer’s repository. |
+
+After you approve, tests **do** run the customer SHA with GKE and platform-license secrets. That is required to test their code. Treat the approval as a trust decision: do not approve a PR that looks like it will dump env or exfiltrate credentials.
+
+`workflow_dispatch` still requires `build-gate` approval and must be run from the default branch so the workflow YAML is the trusted copy. Write access is not a substitute for that approval. Re-run a failed suite with **Re-run failed jobs** instead of dispatching from a feature branch.
+
+## Changelog
+
+There are two different changelog items.
+
+### 1. Customer-written entry (keep it)
+
+Example: [#426](https://github.com/jfrog/terraform-provider-xray/pull/426) already adds a `CHANGELOG.md` bullet for `xray_settings`. That is a normal PR file. **Merging the PR lands that bullet.** CI does not write it.
+
+### 2. CI “Tested on JFrog Platform …” heading (we cannot push to a fork)
+
+The old job rewrote the version heading and `git push`ed to the PR branch. `GITHUB_TOKEN` cannot write to `customer/terraform-provider-xray`.
+
+| PR type | After tests pass |
+|---|---|
+| Same-repo (`jfrog/terraform-provider-xray`) | CI still updates `CHANGELOG.md` and pushes, as before |
+| Fork (customer) | Push is skipped. CI comments on the PR. Slack still asks for review. |
+
+**While merging a customer PR:** resolve `CHANGELOG.md` if it conflicts (move their bullet under the current version), and add the “Tested on …” suffix yourself if you want it. You can do that in the merge conflict UI, as a maintainer edit on their branch (if they allow edits), or as a small commit on `main` after merge.
+
+You do not need to copy the PR onto a new branch just to get CI or changelog.
+
+This matches jfrog-cli: they never push changelog onto a PR. Notes are handled at merge/release time.
+
+## Maintainer flow for a customer PR
+
+1. Review the diff (including their `CHANGELOG.md` bullet).
+2. In Actions, approve the **`build-gate`** environment deployment **once**.
+3. Terraform and OpenTofu acceptance tests run.
+4. When `Build Gate / build-gate-success` is green, merge.
+5. Update the changelog heading / conflict while merging if needed.
+
+To recover a failed test suite: **Re-run failed jobs**. That does not re-ask for `build-gate` approval and does not need a new commit.
+
+## One-time GitHub settings (not in git)
+
+These must be done on `jfrog/terraform-provider-xray` after this lands on `main`:
+
+1. **Settings → Environments → New environment: `build-gate`**
+   - Add **Required reviewers** (the maintainers who today copy customer branches).
+   - Limit **Deployment branches** to the default branch so a modified workflow on another ref cannot use this environment.
+2. Leave test secrets/vars on **`development`** (or repo/org secrets).
+3. **Do not** add required reviewers on `development`, or you will approve twice.
+4. **Branch protection:** require `Build Gate / build-gate-success`. Stop requiring the old matrix job names (`terraform` / `tofu`).
+
+Until `build-gate.yml` is on `main`, `pull_request_target` still uses the old workflow from the default branch.
+
+## Files
+
+| Workflow | Trigger | Role |
+|---|---|---|
+| `build-gate.yml` | `pull_request_target` on `main` (Go / these workflow files), `workflow_dispatch` from the default branch | Approval + call tests + aggregator |
+| `acceptance-tests.yml` | `workflow_call` only | GKE platform + Terraform/OpenTofu tests + changelog |
+| `cla.yml` | `pull_request_target` | CLA (unchanged) |
+| `slack-notify-pr.yml` | `pull_request_target` | Slack notify only (unchanged) |
+| `release.yml` | tag `v*` | Release (unchanged) |

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,18 +1,21 @@
+# Reusable: invoked by build-gate.yml behind the `build-gate` approval.
+# Do not add pull_request, pull_request_target, or workflow_dispatch here —
+# that would either withhold secrets (fork PRs) or run untrusted code with
+# secrets and no gate.
 on:
-  pull_request:
-    branches:
-      - main
-    types: [opened,synchronize]
-    paths:
-      - '**.go'
-  workflow_dispatch:
+  workflow_call:
 
 name: Terraform & OpenTofu Acceptance Tests
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   acceptance-tests-matrix:
     name: ${{ matrix.cli }}
     runs-on: ubuntu-latest
+    # Secret/var source only. Required reviewers belong on `build-gate`, not here.
     environment: development
     strategy:
       fail-fast: true
@@ -28,8 +31,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          # pull_request_target defaults to the base branch; test the PR SHA.
+          # Safe: this job only runs after human approval via build-gate.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
       - name: Install Helm
         uses: azure/setup-helm@v4.2.0
       - name: Get JFrog Platform component versions
@@ -347,15 +355,30 @@ jobs:
     needs: [acceptance-tests-matrix]
     if: |
       always() &&
-      (github.event_name == 'pull_request' && needs.acceptance-tests-matrix.result == 'success')
+      (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+      needs.acceptance-tests-matrix.result == 'success'
     permissions:
       contents: write
+      pull-requests: write
     steps:
+      - name: Skip changelog push on fork PRs
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Fork PR — GITHUB_TOKEN cannot push CHANGELOG.md to ${{ github.event.pull_request.head.repo.full_name }}."
+          echo "Apply the tested-on platform line after merge, or on a same-repo branch."
+          gh pr comment "${{ github.event.pull_request.number }}" --body "Acceptance tests passed. CHANGELOG.md was **not** updated on this fork branch (no write access to the customer repo). After merge, add the tested JFrog Platform / Terraform / OpenTofu versions to the latest CHANGELOG heading, or cherry-pick onto a same-repo branch if you need the line before merge."
       - uses: actions/checkout@v4
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Same SHA the suite tested. Do not checkout the branch name — it may
+          # have moved, and a later push would land the changelog on untested code.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Update CHANGELOG and push commit
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           PLATFORM_VERSION: ${{ needs.acceptance-tests-matrix.outputs.platform_version }}
           ARTIFACTORY_VERSION: ${{ needs.acceptance-tests-matrix.outputs.artifactory_version }}
@@ -363,6 +386,8 @@ jobs:
           CATALOG_VERSION: ${{ needs.acceptance-tests-matrix.outputs.catalog_version }}
           TERRAFORM_VERSION: ${{ needs.acceptance-tests-matrix.outputs.tf_version }}
           OPENTOFU_VERSION: ${{ needs.acceptance-tests-matrix.outputs.tofu_version }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "Adding JFrog Platform version to CHANGELOG.md"
           sed -i -E "0,/(##\s.+\..+\..+\s\(.+\)).*/ s/(##\s.+\..+\..+\s\(.+\)).*/\1. Tested on JFrog Platform $PLATFORM_VERSION (Artifactory $ARTIFACTORY_VERSION, Xray $XRAY_VERSION, Catalog $CATALOG_VERSION) with Terraform $TERRAFORM_VERSION and OpenTofu $OPENTOFU_VERSION/" CHANGELOG.md
@@ -377,7 +402,7 @@ jobs:
             git config --get user.name
             git config --get user.email
             git commit --author="JFrog CI <jfrog-solutions-ci+1@jfrog.com>" -m "JFrog Pipelines - Add JFrog Platform version to CHANGELOG.md"
-            git push
+            git push --force-with-lease="refs/heads/${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:refs/heads/${PR_HEAD_REF}"
           else
             echo "There is nothing to commit: JFrog Platform version hadn't changed."
           fi

--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -1,0 +1,76 @@
+name: Build Gate
+# Single approval gate for fork/PR runs: a maintainer approves the `build-gate`
+# environment deployment once, then acceptance tests receive repo secrets.
+# Workflow YAML always comes from the base branch (pull_request_target), never
+# from the customer fork. Untrusted PR code is checked out only after this gate.
+# Replaces copying customer PRs onto a same-repo branch to obtain secrets.
+#
+# Repo setup (one-time): create environment `build-gate` with Required reviewers.
+# Leave secrets on `development` (or repo/org secrets). Do not also require
+# reviewers on `development` or maintainers will approve twice.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - '.github/workflows/acceptance-tests.yml'
+      - '.github/workflows/build-gate.yml'
+  workflow_dispatch:
+
+# Ensures that only the latest commit is running for each PR at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # The single approval point. `build-gate` carries the Required-reviewers rule.
+  # Manual dispatch uses the same environment (write access is not a substitute
+  # for approval) and is refused unless the selected ref is the default branch,
+  # so a modified copy of this workflow on another branch cannot skip the gate.
+  gate:
+    name: Approval gate
+    runs-on: ubuntu-latest
+    environment: build-gate
+    steps:
+      - name: Require default branch for manual dispatch
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ "${GITHUB_REF}" != "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+            echo "::error::Dispatch Build Gate only from the default branch so this workflow YAML stays trusted."
+            exit 1
+          fi
+          echo "Approved — releasing acceptance tests."
+
+  acceptance-tests:
+    needs: gate
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/acceptance-tests.yml
+    secrets: inherit
+
+  # Single, stable required status check. Point branch protection at
+  # "Build Gate / build-gate-success" instead of the matrix-expanded suite checks.
+  # Recover a failed suite with "Re-run failed jobs" (re-runs the suite + this job,
+  # not the approval gate) — no re-approval and no new commit needed.
+  build-gate-success:
+    name: build-gate-success
+    if: always()
+    needs:
+      - gate
+      - acceptance-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify acceptance tests did not fail or get cancelled
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::Acceptance tests failed or were cancelled."
+            exit 1
+          fi
+          echo "All jobs succeeded (skipped jobs are allowed)."


### PR DESCRIPTION
…tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reviewer-approved build gate before acceptance tests run.
  * Added a stable status check for merge protection.
  * Improved changelog handling for fork pull requests, including notifications when direct updates aren’t available.
  * Added controlled manual workflow runs from the default branch.

* **Documentation**
  * Documented the build-gate workflow, maintainer procedures, required settings, and changelog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->