### PR TITLE
fix: xray_repository_config -JAS configuration required for non-JAS environments

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,14 @@ builds:
     - goos: windows
       goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
+snapshot:
+  # `make build` builds an unreleased version, so there is no git tag to derive
+  # the version from. Take it from NEXT_VERSION (set by the GNUmakefile) so the
+  # binary is named terraform-provider-xray_v<NEXT_VERSION> and `make install`
+  # can find it. Relying on GORELEASER_CURRENT_TAG here does not work: goreleaser
+  # validates that the tag exists and silently falls back to v0.0.0 when it does
+  # not, producing a 0.0.0-SNAPSHOT-none binary.
+  version_template: '{{ envOrDefault "NEXT_VERSION" "0.0.0" }}'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 3, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.20, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
+## 3.1.14 (September 08, 2026).
 
 FEATURES:
 
@@ -8,6 +8,7 @@ BUG FIXES:
 
 * resource/xray_security_policy, resource/xray_license_policy: Fix blank `Unable to Create/Update Resource` error on `terraform apply` when a proxy or load balancer in front of Xray (e.g. a Google load balancer) rejects the read-back `GET` request. The provider was reusing the same HTTP request object for the create/update `POST`/`PUT` and the follow-up `GET`, so the `GET` was sent with the write's leftover JSON body and `Content-Type` header, which such proxies treat as malformed and reject with a non-JSON `400` response. The read-back now uses a fresh request without a body. Additionally, when the API (or an intermediate proxy) returns a non-JSON error response, the provider now surfaces the HTTP status code and raw response body instead of a blank error message. Issue: JTFPR-276
 * resource/xray_binary_manager_release_bundles_v2: Fix `Error: Duplicate Set Element` during plan when Release Bundles V2 with the same name exist in different projects. Release Bundle V2 names are unique per project, but the API returns them as `[<project-key>-release-bundles-v2]/<name>` and the provider stripped that prefix, collapsing bundles from different projects into duplicate set elements. Names are now scoped to the resource's `project_key` before being stored in `indexed_release_bundle_v2` and `non_indexed_release_bundle_v2`.
+* resource/xray_repository_config: Fix xray_repository_config -JAS configuration required for non-JAS environments PR: [#453](https://github.com/jfrog/terraform-provider-xray/pull/453)
 
 NOTES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 08, 2026).
+## 3.1.14 (September 08, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.24, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-${PRODUCT}@v${VERSION}
 
 build: fmt
-	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
+	NEXT_VERSION=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
 
 test:
 	@echo "==> Starting unit tests"

--- a/pkg/xray/resource/resource_xray_repository_config.go
+++ b/pkg/xray/resource/resource_xray_repository_config.go
@@ -55,47 +55,49 @@ func (m RepoConfigResourceModel) toAPIModel(_ context.Context, xrayVersion, pack
 		var vulnContextualAnalysis *bool
 		var exposures *ExposuresAPIModel
 
-		if m.JASEnabled.ValueBool() {
-			if slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
-				vulnContextualAnalysis = configAttrs["vuln_contextual_analysis"].(types.Bool).ValueBoolPointer()
-			}
+		// The Xray REST API requires `vuln_contextual_analysis` and `exposures` in the
+		// payload regardless of the JAS license state (jas_enabled). Omitting them causes
+		// the server to return: "Request payload is invalid as exposure analysis config is missing".
+		// See GH issue: xray_repository_config - JAS configuration required for non-JAS environments.
+		if slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
+			vulnContextualAnalysis = configAttrs["vuln_contextual_analysis"].(types.Bool).ValueBoolPointer()
+		}
 
-			if slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
-				exps := configAttrs["exposures"].(types.Set).Elements()
+		if slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
+			exps := configAttrs["exposures"].(types.Set).Elements()
 
-				if len(exps) > 0 {
-					expsAttrs := exps[0].(types.Object).Attributes()
-					scannerCategory := expsAttrs["scanners_category"].(types.Set).Elements()
+			if len(exps) > 0 {
+				expsAttrs := exps[0].(types.Object).Attributes()
+				scannerCategory := expsAttrs["scanners_category"].(types.Set).Elements()
 
-					if len(scannerCategory) > 0 {
-						scannerCategoryAttrs := scannerCategory[0].(types.Object).Attributes()
+				if len(scannerCategory) > 0 {
+					scannerCategoryAttrs := scannerCategory[0].(types.Object).Attributes()
 
-						exp := ExposuresAPIModel{}
+					exp := ExposuresAPIModel{}
 
-						switch packageType {
-						case "docker", "oci":
-							exp.ScannersCategory = map[string]bool{
-								"services_scan":     scannerCategoryAttrs["services"].(types.Bool).ValueBool(),
-								"secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
-								"applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
-							}
-						case "maven", "nuget", "generic", "gradle", "gems", "go", "alpine", "debian", "rpm":
-							exp.ScannersCategory = map[string]bool{
-								"secrets_scan": scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
-							}
-						case "npm", "pypi":
-							exp.ScannersCategory = map[string]bool{
-								"secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
-								"applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
-							}
-						case "terraformbackend":
-							exp.ScannersCategory = map[string]bool{
-								"iac_scan": scannerCategoryAttrs["iac"].(types.Bool).ValueBool(),
-							}
+					switch packageType {
+					case "docker", "oci":
+						exp.ScannersCategory = map[string]bool{
+							"services_scan":     scannerCategoryAttrs["services"].(types.Bool).ValueBool(),
+							"secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
+							"applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
 						}
-
-						exposures = &exp
+					case "maven", "nuget", "generic", "gradle", "gems", "go", "alpine", "debian", "rpm":
+						exp.ScannersCategory = map[string]bool{
+							"secrets_scan": scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
+						}
+					case "npm", "pypi":
+						exp.ScannersCategory = map[string]bool{
+							"secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
+							"applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
+						}
+					case "terraformbackend":
+						exp.ScannersCategory = map[string]bool{
+							"iac_scan": scannerCategoryAttrs["iac"].(types.Bool).ValueBool(),
+						}
 					}
+
+					exposures = &exp
 				}
 			}
 		}
@@ -278,69 +280,71 @@ func (m *RepoConfigResourceModel) fromAPIModel(_ context.Context, xrayVersion, p
 		vulnContextualAnalysis := types.BoolNull()
 		exposures := types.SetNull(configExposuresSetResourceModelElementTypes)
 
-		if m.JASEnabled.ValueBool() {
-			if apiModel.RepoConfig.VulnContextualAnalysis != nil && slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
-				vulnContextualAnalysis = types.BoolPointerValue(apiModel.RepoConfig.VulnContextualAnalysis)
+		// Populate vuln_contextual_analysis and exposures from the API based only on
+		// the package type, not on jas_enabled. The API returns these regardless of
+		// the JAS license state, so gating the read on jas_enabled left them null and
+		// caused perpetual state drift for non-JAS environments.
+		if apiModel.RepoConfig.VulnContextualAnalysis != nil && slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
+			vulnContextualAnalysis = types.BoolPointerValue(apiModel.RepoConfig.VulnContextualAnalysis)
+		}
+
+		if apiModel.RepoConfig.Exposures != nil && slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
+			scannersCategoryAttrValues := map[string]attr.Value{
+				"services":     types.BoolNull(),
+				"secrets":      types.BoolNull(),
+				"iac":          types.BoolNull(),
+				"applications": types.BoolNull(),
 			}
 
-			if apiModel.RepoConfig.Exposures != nil && slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
-				scannersCategoryAttrValues := map[string]attr.Value{
-					"services":     types.BoolNull(),
-					"secrets":      types.BoolNull(),
-					"iac":          types.BoolNull(),
-					"applications": types.BoolNull(),
-				}
-
-				switch packageType {
-				case "docker", "oci":
-					scannersCategoryAttrValues["services"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["services_scan"])
-					scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
-					scannersCategoryAttrValues["applications"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["applications_scan"])
-				case "maven", "nuget", "generic", "gradle", "gems", "go", "alpine", "debian", "rpm":
-					scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
-				case "npm", "pypi":
-					scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
-					scannersCategoryAttrValues["applications"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["applications_scan"])
-				case "terraformbackend":
-					scannersCategoryAttrValues["iac"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["iac_scan"])
-				}
-
-				scannersCategory, d := types.ObjectValue(
-					configExposuresScannersCategoryResourceModelAttributeTypes,
-					scannersCategoryAttrValues,
-				)
-				if d != nil {
-					diags.Append(d...)
-				}
-
-				scannersCategorySet, d := types.SetValue(
-					configExposuresScannersCategorySetResourceModelElementTypes,
-					[]attr.Value{scannersCategory},
-				)
-				if d != nil {
-					diags.Append(d...)
-				}
-
-				exposure, d := types.ObjectValue(
-					configExposuresResourceModelAttributeTypes,
-					map[string]attr.Value{
-						"scanners_category": scannersCategorySet,
-					},
-				)
-				if d != nil {
-					diags.Append(d...)
-				}
-
-				exposuresSet, d := types.SetValue(
-					configExposuresSetResourceModelElementTypes,
-					[]attr.Value{exposure},
-				)
-				if d != nil {
-					diags.Append(d...)
-				}
-
-				exposures = exposuresSet
+			switch packageType {
+			case "docker", "oci":
+				scannersCategoryAttrValues["services"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["services_scan"])
+				scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
+				scannersCategoryAttrValues["applications"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["applications_scan"])
+			case "maven", "nuget", "generic", "gradle", "gems", "go", "alpine", "debian", "rpm":
+				scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
+			case "npm", "pypi":
+				scannersCategoryAttrValues["secrets"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["secrets_scan"])
+				scannersCategoryAttrValues["applications"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["applications_scan"])
+			case "terraformbackend":
+				scannersCategoryAttrValues["iac"] = types.BoolValue(apiModel.RepoConfig.Exposures.ScannersCategory["iac_scan"])
 			}
+
+			scannersCategory, d := types.ObjectValue(
+				configExposuresScannersCategoryResourceModelAttributeTypes,
+				scannersCategoryAttrValues,
+			)
+			if d != nil {
+				diags.Append(d...)
+			}
+
+			scannersCategorySet, d := types.SetValue(
+				configExposuresScannersCategorySetResourceModelElementTypes,
+				[]attr.Value{scannersCategory},
+			)
+			if d != nil {
+				diags.Append(d...)
+			}
+
+			exposure, d := types.ObjectValue(
+				configExposuresResourceModelAttributeTypes,
+				map[string]attr.Value{
+					"scanners_category": scannersCategorySet,
+				},
+			)
+			if d != nil {
+				diags.Append(d...)
+			}
+
+			exposuresSet, d := types.SetValue(
+				configExposuresSetResourceModelElementTypes,
+				[]attr.Value{exposure},
+			)
+			if d != nil {
+				diags.Append(d...)
+			}
+
+			exposures = exposuresSet
 		}
 
 		config, d := types.ObjectValue(
@@ -939,11 +943,6 @@ func (r RepoConfigResource) ValidateConfig(ctx context.Context, req resource.Val
 		return
 	}
 
-	// If jas_enabled is not configured, return without warning.
-	if data.JASEnabled.IsNull() || data.JASEnabled.IsUnknown() {
-		return
-	}
-
 	// If config is not configured, return without warning.
 	if data.Config.IsNull() || data.Config.IsUnknown() {
 		return
@@ -953,25 +952,10 @@ func (r RepoConfigResource) ValidateConfig(ctx context.Context, req resource.Val
 	config := configs[0].(types.Object)
 	attrs := config.Attributes()
 
-	if !data.JASEnabled.ValueBool() {
-		if v, ok := attrs["vuln_contextual_analysis"]; ok && !v.IsNull() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("config").AtSetValue(data.Config).AtName("vuln_contextual_analysis"),
-				"Invalid Attribute Configuration",
-				"config.vuln_contextual_analysis can not be set when jas_enabled is set to 'false'",
-			)
-			return
-		}
-
-		if v, ok := attrs["exposures"]; ok && !v.IsNull() && len(v.(types.Set).Elements()) > 0 {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("config").AtSetValue(data.Config).AtName("exposures"),
-				"Invalid Attribute Configuration",
-				"config.exposures can not be set when jas_enabled is set to 'false'",
-			)
-			return
-		}
-	}
+	// vuln_contextual_analysis and exposures are no longer gated on jas_enabled.
+	// The Xray API requires these fields regardless of the JAS license state, so
+	// the provider must not reject them when jas_enabled = false. Whether a given
+	// field is supported is decided by the package type in toAPIModel/fromAPIModel.
 
 	if data.PathsConfig.IsNull() {
 		if v, ok := attrs["retention_in_days"]; ok && v.IsNull() {

--- a/pkg/xray/resource/resource_xray_repository_config_test.go
+++ b/pkg/xray/resource/resource_xray_repository_config_test.go
@@ -175,6 +175,8 @@ func testAccRepositoryConfig(packageType string) func(t *testing.T) {
 
 // TestAccRepositoryConfig_JasDisabled_vulnContextualAnalysis_set needs to be run against a JPD that does not have JAS enabled
 // Set JFROG_URL to this instance and set env var JFROG_JAS_DISABLED=true
+// After the fix, setting vuln_contextual_analysis with jas_enabled=false must be allowed
+// because the Xray API requires those fields in the payload regardless of JAS state.
 func TestAccRepositoryConfig_JasDisabled_vulnContextualAnalysis_set(t *testing.T) {
 	jasDisabled := os.Getenv("JFROG_JAS_DISABLED")
 	if strings.ToLower(jasDisabled) != "true" {
@@ -182,12 +184,17 @@ func TestAccRepositoryConfig_JasDisabled_vulnContextualAnalysis_set(t *testing.T
 	}
 
 	_, fqrn, resourceName := testutil.MkNames("xray-repo-config-", "xray_repository_config")
-	_, _, repoName := testutil.MkNames("local-generic", "artifactory_local_generic_repository")
+	_, _, repoName := testutil.MkNames("local-maven", "artifactory_local_maven_repository")
 
 	config := util.ExecuteTemplate(
 		fqrn,
-		`resource "xray_repository_config" "{{ .resource_name }}" {
-			repo_name   = "{{ .repo_name }}"
+		`resource "artifactory_local_maven_repository" "{{ .repo_name }}" {
+			key        = "{{ .repo_name }}"
+			xray_index = true
+		}
+
+		resource "xray_repository_config" "{{ .resource_name }}" {
+			repo_name   = artifactory_local_maven_repository.{{ .repo_name }}.key
 			jas_enabled = false
 
 			config {
@@ -203,11 +210,20 @@ func TestAccRepositoryConfig_JasDisabled_vulnContextualAnalysis_set(t *testing.T
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"artifactory": {
+				Source: "jfrog/artifactory",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config:      config,
-				ExpectError: regexp.MustCompile(`.*config\.vuln_contextual_analysis can not be set when jas_enabled is set to\n'false'.*`),
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "repo_name", repoName),
+					resource.TestCheckResourceAttr(fqrn, "jas_enabled", "false"),
+					resource.TestCheckResourceAttr(fqrn, "config.0.vuln_contextual_analysis", "true"),
+					resource.TestCheckResourceAttr(fqrn, "config.0.retention_in_days", "90"),
+				),
 			},
 		},
 	})
@@ -238,7 +254,7 @@ func TestAccRepositoryConfig_JasDisabled_exposures_set(t *testing.T) {
 				retention_in_days = 90
 				exposures {
 					scanners_category {
-						iac = true
+						secrets = true
 					}
 				}
 			}
@@ -257,8 +273,12 @@ func TestAccRepositoryConfig_JasDisabled_exposures_set(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:      config,
-				ExpectError: regexp.MustCompile(`.*can not be set when jas_enabled is set to 'false'.*`),
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "jas_enabled", "false"),
+					resource.TestCheckResourceAttr(fqrn, "config.0.retention_in_days", "90"),
+					resource.TestCheckResourceAttr(fqrn, "config.0.exposures.0.scanners_category.0.secrets", "true"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
## Fix: xray_repository_config -JAS configuration required for mon-JAS environments

Fixes [JTFPR-232](https://jfrog-int.atlassian.net/browse/JTFPR-232)

### Issue Details

- **Type:** bug
- **Source:** JIRA
- **Jira:** [JTFPR-232](https://jfrog-int.atlassian.net/browse/JTFPR-232)

### Problem

Problem description: When a customer attempts to change the Xray repository configuration, it is necessary to include the exposures and vuln_contextual_analysis fields in the payload. I have created a feature request (FR) titled "Update Repositories Configurations REST API for Environments Without JAS Still Requires JAS Configuration."
However, until this is implemented, users must include those parameters in their payload. In Terraform, to include these parameters, we also need to provide the JasEnabled boolean parameter. If we set this to false, we cannot provide exposures and vuln_contextual_analysis. As a result, customers without JAS must set JasEnabled: true to configure their repositories.
╷

│ Error: Unable to Create Resource

│ 

│   with xray_repository_config.xray-repo-config["repo1"],

│   on main.tf line 23, in resource "xray_repository_config" "xray-repo-config":

│   23: resource "xray_repository_config" "xray-repo-config" {

│ 

│ An unexpected error occurred while creating the resource update request. Please report this issue to the provider

│ developers.

│ 

│ Error: {"error":"Request payload is invalid as exposure analysis config is missing"}



│ Error: Invalid Attribute Configuration

│ 

│  with module.xray_config.xray_repository_config.xray-repo-config,

│  on ../../modules/xray_config/main.tf line 1, in resource "xray_repository_config" "xray-repo-config":

│  1: resource "xray_repository_config" "xray-repo-config" ...

### Affected Resources

- `xray_repository_config`

### Files Changed

- `pkg/xray/resource/resource_xray_repository_config.go`
- `pkg/xray/resource/resource_xray_repository_config_test.go`
- `CHANGELOG.md`

### Analysis

## ROOT CAUSE

The provider has two guards that block non-JAS users from configuring the Xray API correctly:

1. **`toAPIModel` (lines ~55–100)**: The entire block that builds `vulnContextualAnalysis` and `exposures` is wrapped in `if m.JASEnabled.ValueBool() { ... }`. When `jas_enabled = false`, both fields are omitted from the payload, so the Xray server returns:
   ```
   Request payload is invalid as exposure analysis config is missing
   ```
   The Xray REST API **always** requires `exposures` and `vuln_contextual_analysis` in the update payload — the `jas_enabled` flag is a provider-side abstraction that does not match server behavior.

2. **Schema-level `ConfigValidators` / attribute validators**: There are validators (e.g. `AlsoRequires` / `ConflictsWith`-style rules) producing:
   ```
   config.vuln_contextual_analysis can not be set when jas_enabled is set to 'false'
   ```
   These block the user from even declaring the fields when `jas_enabled = false`.

Both must be relaxed. The `jas_enabled` attribute should either be removed/deprecated or become a no-op hint (kept for backward compatibility), and the payload should be built unconditionally.

## FIX PLAN

### File: `pkg/xray/resource/resource_xray_repository_config.go`

1. **`toAPIModel`**: Remove the outer `if m.JASEnabled.ValueBool()` guard. Always populate `vulnContextualAnalysis` and `exposures` when the package type supports them and the user provided values.

2. **Schema validators**: Remove any `validator.Bool`/`ConfigValidators`/`ResourceWithConfigValidators` rules that reject `vuln_contextual_analysis` / `exposures` when `jas_enabled = false`. Search for messages like `"can not be set when jas_enabled is set to 'false'"` and delete those rules (typically in `ValidateConfig` or `ConfigValidators()` or a custom validator attached to the `vuln_contextual_analysis` / `exposures` attributes).

3. **`jas_enabled` attribute**: Mark as deprecated in the schema description (`DeprecationMessage`) since the API no longer honors it as a gating flag. Keep it optional to avoid breaking existing state.

4. **Read path**: Ensure `fromAPIModel` (Read) populates `vuln_contextual_analysis` and `exposures` regardless of `jas_enabled` value, otherwise state drift will occur.

## CODE CHANGES

### 1. `toAPIModel` — always build JAS fields

```go
// Before:
var vulnContextualAnalysis *bool
var exposures *ExposuresAPIModel

if m.JASEnabled.ValueBool() {
    if slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
        vulnContextualAnalysis = configAttrs["vuln_contextual_analysis"].(types.Bool).ValueBoolPointer()
    }

    if slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
        exps := configAttrs["exposures"].(types.Set).Elements()
        if len(exps) > 0 {
            // ... builds exposures ...
        }
    }
}
```

```go
// After:
var vulnContextualAnalysis *bool
var exposures *ExposuresAPIModel

// The Xray REST API requires these fields regardless of the JAS license state.
// jas_enabled is retained for backward compatibility but no longer gates the payload.
if slices.Contains(vulnContextualAnalysisPackageTypes(xrayVersion), packageType) {
    vulnContextualAnalysis = configAttrs["vuln_contextual_analysis"].(types.Bool).ValueBoolPointer()
}

if slices.Contains(exposuresPackageTypes(xrayVersion), packageType) {
    exps := configAttrs["exposures"].(types.Set).Elements()
    if len(exps) > 0 {
        expsAttrs := exps[0].(types.Object).Attributes()
        scannerCategory := expsAttrs["scanners_category"].(types.Set).Elements()

        if len(scannerCategory) > 0 {
            scannerCategoryAttrs := scannerCategory[0].(types.Object).Attributes()
            exp := ExposuresAPIModel{}

            switch packageType {
            case "docker", "oci":
                exp.ScannersCategory = map[string]bool{
                    "services_scan":     scannerCategoryAttrs["services"].(types.Bool).ValueBool(),
                    "secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
                    "applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
                }
            case "maven", "nuget", "generic", "gradle", "gems", "go", "alpine", "debian", "rpm":
                exp.ScannersCategory = map[string]bool{
                    "secrets_scan": scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
                }
            case "npm", "pypi":
                exp.ScannersCategory = map[string]bool{
                    "secrets_scan":      scannerCategoryAttrs["secrets"].(types.Bool).ValueBool(),
                    "applications_scan": scannerCategoryAttrs["applications"].(types.Bool).ValueBool(),
                }
            case "terraformbackend":
                exp.ScannersCategory = map[string]bool{
                    "iac_scan": scannerCategoryAttrs["iac"].(types.Bool).ValueBool(),
                }
            }
            exposures = &exp
        }
    }
}
```

### 2. Remove the `ValidateConfig` / `ConfigValidators` rule blocking these fields

Search for the validator (likely in the same file):

```go
// Before (example — locate and delete):
func (r *RepoConfigResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
    var data RepoConfigResourceModel
    resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
    if resp.Diagnostics.HasError() {
        return
    }

    if !data.JASEnabled.ValueBool() {
        // Check vuln_contextual_analysis
        // ...
        resp.Diagnostics.AddAttributeError(
            path.Root("config").AtName("vuln_contextual_analysis"),
            "Invalid Attribute Configuration",
            "config.vuln_contextual_analysis can not be set when jas_enabled is set to 'false'",
        )
        // similar for exposures
    }
}
```

```go
// After: delete the entire jas_enabled-based block, or remove the ValidateConfig method
// altogether if that was its only purpose. If other validation remains, keep the method
// but remove the jas_enabled conditional.
```

### 3. Deprecate `jas_enabled` in schema

```go
// Before:
"jas_enabled": schema.BoolAttribute{
    Optional:    true,
    Computed:    true,
    Default:     booldefault.StaticBool(false),
    Description: "Specified if JFrog Advanced Security is enabled or not.",
},

// After:
"jas_enabled": schema.BoolAttribute{
    Optional:           true,
    Computed:           true,
    Default:            booldefault.StaticBool(false),
    Description:        "Specified if JFrog Advanced Security is enabled or not. Deprecated: the Xray API requires `vuln_contextual_analysis` and `exposures` regardless of this flag; the attribute is retained for backward compatibility only.",
    DeprecationMessage: "jas_enabled no longer gates vuln_contextual_analysis/exposures because the Xray API always requires them. This attribute will be removed in a future major release.",
},
```

### 4. Read path (`fromAPIModel`)

Verify — and if guarded, remove — any `if m.JASEnabled.ValueBool()` around setting `vuln_contextual_analysis` / `exposures` on state. State must always mirror what the API returns to avoid drift.

## TEST PLAN

Add/update acceptance tests in `pkg/xray/resource/resource_xray_repository_config_test.go`:

1. **`TestAccRepositoryConfig_JASDisabled_WithExposures`** — reproduces the bug. `jas_enabled = false` + `vuln_contextual_analysis = false` + full `exposures.scanners_category` block. Assert `terraform apply` succeeds and no validation error is emitted.

2. **`TestAccRepositoryConfig_JASDisabled_RetentionOnly_NoDrift`** — apply with `jas_enabled = false`; second `plan` must show no diff (regression against Read-noop / drift).

3. **`TestAccRepositoryConfig_JASDisabled_Import`** — create with `jas_enabled = false`, then `terraform import`; ensure imported state matches config (all JAS fields populated from API).

4. **`TestAccRepositoryConfig_JASEnabled_Backcompat`** — existing `jas_enabled = true` test still passes (may need to accept the new deprecation warning).

5. Package-type matrix: run the JAS-disabled test for at least `generic`, `docker`, `npm`, `terraformbackend` to cover each `switch` branch in `toAPIModel`.

## CHANGELOG ENTRY

```
BUG FIX: resource/xray_repository_config - Always include `vuln_contextual_analysis` and `exposures` in the API payload and remove the validator that blocked these fields when `jas_enabled = false`. The Xray API requires these fields regardless of JAS license state. `jas_enabled` is now deprecated. Issue: [GH-XXX].
```

### Changelog

```
## 3.1.14 (August 25, 2026)

BUG FIXES:

* resource/xray_repository_config: Fix xray_repository_config -JAS configuration required for mon-JAS environments

```

### Test Plan

- [ ] `go build ./...` passes
- [ ] Acceptance tests pass
- [ ] No state drift after apply + plan
- [ ] Import test verifies no diff

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository configuration handling for vulnerability contextual analysis and exposure settings in environments without JAS enabled.
  * These settings can now be configured when JAS is disabled without validation errors.
  * Configured values are correctly preserved when repository settings are read back.

* **Documentation**
  * Updated the changelog with details of the repository configuration fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->