### PR TITLE
fix: Xray terraform provider will plan changes to policy rules on an existing state then fail to apply them with "Provider produced inconsistent result after apply" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * data/xray_curation_condition: Add a new data source which looks up a built-in or custom Curation condition by its exact name (case-sensitive) and exposes its numeric `id`, so `xray_curation_policy.condition_id` no longer has to be hard-coded to a raw numeric ID. Issue: JTFPR-341 PR: [#452](https://github.com/jfrog/terraform-provider-xray/pull/452)
 
+BUG FIXES:
+
+* resource/xray_security_policy, resource/xray_license_policy, resource/xray_operational_risk_policy: Fix `Provider produced inconsistent result after apply ... produced an unexpected new value: .rule[N].name` when planning changes to the rules of an existing policy. The provider re-sorted the rules returned by the API by `priority` before writing them to state, which reordered the `rule` list whenever the configuration was not authored in ascending-priority order. Rules are now written back in the order they appear in the plan or prior state, keyed by rule name, and `fail_pull_request` is carried over by rule name instead of by list position. Issue: JTFPR-371 PR: [#454](https://github.com/jfrog/terraform-provider-xray/pull/454)
+
 ## 3.1.13 (Aug 21, 2026). Tested on JFrog Platform 11.6.1 (Artifactory 7.161.16, Xray 3.150.24, Catalog 1.44.0) with Terraform 1.15.8 and OpenTofu 1.12.5
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (August 25, 2026). Tested on JFrog Platform 11.6.2 (Artifactory 7.161.19, Xray 3.150.33, Catalog 1.46.1) with Terraform 1.16.0 and OpenTofu 1.12.6
+## 3.1.14 (August 25, 2026). Tested on JFrog Platform 11.6.2 (Artifactory 7.161.19, Xray 3.150.33, Catalog 1.46.1). Tested on JFrog Platform 11.6.2 (Artifactory 7.161.19, Xray 3.150.33, Catalog 1.46.1) with Terraform 1.16.0 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/pkg/xray/resource/policies.go
+++ b/pkg/xray/resource/policies.go
@@ -254,6 +254,12 @@ var fromActionsAPIModel = func(ctx context.Context, actionsAPIModel PolicyRuleAc
 	return actionsList, diags
 }
 
+// fromAPIModel populates the resource model from an Xray policy API response,
+// delegating the per-rule criteria and actions conversion to the callbacks
+// supplied by each policy resource. The rules returned by the API are realigned
+// to the order already held in m.Rules (the plan on Create/Update, the prior
+// state on Read) before being written back, so the `rule` list stays positionally
+// consistent with what Terraform planned.
 func (m *PolicyResourceModel) fromAPIModel(
 	ctx context.Context,
 	apiModel PolicyAPIModel,
@@ -698,12 +704,26 @@ type PolicyError struct {
 // preserveFailPullRequest copies fail_pull_request from the source API model
 // to the target API model. The Xray API accepts fail_pull_request in POST/PUT
 // but does not return it in GET responses, so we must preserve the value from
-// the plan or state to avoid state drift.
+// the plan or state to avoid state drift. Rules are matched by name, since the
+// API does not guarantee it echoes rules back in the order they were sent and
+// matching by position would attach the value to the wrong rule.
 func preserveFailPullRequest(source, target *[]PolicyRuleAPIModel) {
 	if source == nil || target == nil {
 		return
 	}
+
+	failPRByName := make(map[string]*FailPullRequestAPIModel, len(*source))
+	for _, rule := range *source {
+		failPRByName[rule.Name] = rule.Actions.FailPullRequest
+	}
+
 	for i := range *target {
+		if failPR, ok := failPRByName[(*target)[i].Name]; ok {
+			(*target)[i].Actions.FailPullRequest = failPR
+			continue
+		}
+		// No rule with a matching name (e.g. the rule was renamed); fall back to
+		// positional matching rather than dropping the value entirely.
 		if i < len(*source) {
 			(*target)[i].Actions.FailPullRequest = (*source)[i].Actions.FailPullRequest
 		}
@@ -711,28 +731,27 @@ func preserveFailPullRequest(source, target *[]PolicyRuleAPIModel) {
 }
 
 // extractFailPullRequestFromState extracts fail_pull_request values from the
-// Terraform state's rules list and applies them to the API model rules.
+// Terraform state's rules list and applies them to the API model rules, matching
+// rules by name rather than by position for the same reason as
+// preserveFailPullRequest.
 func extractFailPullRequestFromState(state PolicyResourceModel, target *[]PolicyRuleAPIModel) {
 	if target == nil {
 		return
 	}
 
-	for i, elem := range state.Rules.Elements() {
-		if i >= len(*target) {
-			break
-		}
-
+	failPRByName := make(map[string]bool, len(state.Rules.Elements()))
+	for _, elem := range state.Rules.Elements() {
 		ruleObj, ok := elem.(types.Object)
 		if !ok {
 			continue
 		}
 
-		actionsAttr, ok := ruleObj.Attributes()["actions"]
-		if !ok {
+		nameAttr, ok := ruleObj.Attributes()["name"].(types.String)
+		if !ok || nameAttr.IsNull() || nameAttr.IsUnknown() {
 			continue
 		}
 
-		actionsList, ok := actionsAttr.(types.List)
+		actionsList, ok := ruleObj.Attributes()["actions"].(types.List)
 		if !ok || len(actionsList.Elements()) == 0 {
 			continue
 		}
@@ -742,18 +761,19 @@ func extractFailPullRequestFromState(state PolicyResourceModel, target *[]Policy
 			continue
 		}
 
-		failPR, ok := actionsObj.Attributes()["fail_pull_request"]
-		if !ok {
-			continue
-		}
-
-		failPRBool, ok := failPR.(types.Bool)
+		failPRBool, ok := actionsObj.Attributes()["fail_pull_request"].(types.Bool)
 		if !ok || failPRBool.IsNull() || failPRBool.IsUnknown() {
 			continue
 		}
 
-		(*target)[i].Actions.FailPullRequest = &FailPullRequestAPIModel{
-			Active: failPRBool.ValueBool(),
+		failPRByName[nameAttr.ValueString()] = failPRBool.ValueBool()
+	}
+
+	for i := range *target {
+		if active, ok := failPRByName[(*target)[i].Name]; ok {
+			(*target)[i].Actions.FailPullRequest = &FailPullRequestAPIModel{
+				Active: active,
+			}
 		}
 	}
 }

--- a/pkg/xray/resource/policies.go
+++ b/pkg/xray/resource/policies.go
@@ -277,11 +277,39 @@ func (m *PolicyResourceModel) fromAPIModel(
 		ruleSetElementType = opRiskRuleSetElementType
 	}
 
-	// Sort rules by priority to ensure consistent ordering between config and API response
+	// Preserve the rule order from the prior plan/state (m.Rules) so the list written
+	// to state is positionally consistent with what Terraform planned. Sorting by
+	// priority is wrong: priority is not unique and has no relationship to config
+	// declaration order, which causes "Provider produced inconsistent result after
+	// apply" when config order differs from ascending-priority order. Rule names are
+	// unique (enforced by ValidateConfig), so name is a safe reordering key. Rules not
+	// present in the prior order (e.g. during import, where m.Rules is null) fall back
+	// to the API response order.
 	apiRules := *apiModel.Rules
-	sort.Slice(apiRules, func(i, j int) bool {
-		return apiRules[i].Priority < apiRules[j].Priority
-	})
+	if !m.Rules.IsNull() && !m.Rules.IsUnknown() {
+		order := make(map[string]int, len(m.Rules.Elements()))
+		for idx, elem := range m.Rules.Elements() {
+			if obj, ok := elem.(types.Object); ok {
+				if nameAttr, ok := obj.Attributes()["name"].(types.String); ok {
+					order[nameAttr.ValueString()] = idx
+				}
+			}
+		}
+		sort.SliceStable(apiRules, func(i, j int) bool {
+			oi, oki := order[apiRules[i].Name]
+			oj, okj := order[apiRules[j].Name]
+			switch {
+			case oki && okj:
+				return oi < oj
+			case oki:
+				return true
+			case okj:
+				return false
+			default:
+				return false
+			}
+		})
+	}
 
 	rules := lo.Map(
 		apiRules,

--- a/pkg/xray/resource/resource_xray_security_policy_test.go
+++ b/pkg/xray/resource/resource_xray_security_policy_test.go
@@ -233,6 +233,49 @@ func TestAccSecurityPolicy_multipleRules(t *testing.T) {
 	})
 }
 
+// TestAccSecurityPolicy_rulesPreserveConfigOrder is a regression test for the
+// "Provider produced inconsistent result after apply" bug: when rules are declared
+// in an order that does NOT match ascending priority, the provider must keep the
+// config declaration order in state instead of sorting by priority. The first
+// declared rule has a HIGHER priority than the second, so a priority-based sort would
+// reorder the list and violate the plan/apply consistency contract.
+func TestAccSecurityPolicy_rulesPreserveConfigOrder(t *testing.T) {
+	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
+	testData := sdk.MergeMaps(testDataSecurity)
+
+	testData["resource_name"] = resourceName
+	testData["policy_name"] = fmt.Sprintf("terraform-security-policy-order-%d", testutil.RandomInt())
+	testData["rule_name_1"] = fmt.Sprintf("test-security-rule-order-a-%d", testutil.RandomInt())
+	testData["rule_name_2"] = fmt.Sprintf("test-security-rule-order-b-%d", testutil.RandomInt())
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckPolicy),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicyTwoRulesUnorderedPriority, testData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "rule.#", "2"),
+					// Indexed (order-sensitive) checks: declaration order must be preserved
+					// even though rule.0 has a higher priority than rule.1.
+					resource.TestCheckResourceAttr(fqrn, "rule.0.name", testData["rule_name_1"]),
+					resource.TestCheckResourceAttr(fqrn, "rule.0.priority", "2"),
+					resource.TestCheckResourceAttr(fqrn, "rule.1.name", testData["rule_name_2"]),
+					resource.TestCheckResourceAttr(fqrn, "rule.1.priority", "1"),
+				),
+			},
+			{
+				Config: util.ExecuteTemplate(fqrn, securityPolicyTwoRulesUnorderedPriority, testData),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccSecurityPolicy_unknownMinSeveritySecurityPolicy_beforeVersion3602(t *testing.T) {
 	_, fqrn, resourceName := testutil.MkNames("policy-", "xray_security_policy")
 
@@ -1671,6 +1714,59 @@ const securityPolicyTwoRules = `resource "xray_security_policy" "{{ .resource_na
 	rule {
 		name = "{{ .rule_name_2 }}"
 		priority = 2
+		criteria {
+			cvss_range {
+				from = {{ .cvss_from }}
+				to = {{ .cvss_to }}
+			}
+		}
+		actions {
+			block_release_bundle_distribution = {{ .block_release_bundle_distribution }}
+			block_release_bundle_promotion = {{ .block_release_bundle_promotion }}
+			fail_build = {{ .fail_build }}
+			notify_watch_recipients = {{ .notify_watch_recipients }}
+			notify_deployer = {{ .notify_deployer }}
+			create_ticket_enabled = {{ .create_ticket_enabled }}
+			fail_pull_request = {{ .fail_pull_request }}
+			build_failure_grace_period_in_days = {{ .grace_period_days }}
+			block_download {
+				unscanned = {{ .block_unscanned }}
+				active = {{ .block_active }}
+			}
+		}
+	}
+}`
+
+const securityPolicyTwoRulesUnorderedPriority = `resource "xray_security_policy" "{{ .resource_name }}" {
+	name = "{{ .policy_name }}"
+	description = "{{ .policy_description }}"
+	type = "security"
+
+	rule {
+		name = "{{ .rule_name_1 }}"
+		priority = 2
+		criteria {
+			min_severity = "{{ .min_severity }}"
+		}
+		actions {
+			block_release_bundle_distribution = {{ .block_release_bundle_distribution }}
+			block_release_bundle_promotion = {{ .block_release_bundle_promotion }}
+			fail_build = {{ .fail_build }}
+			notify_watch_recipients = {{ .notify_watch_recipients }}
+			notify_deployer = {{ .notify_deployer }}
+			create_ticket_enabled = {{ .create_ticket_enabled }}
+			fail_pull_request = {{ .fail_pull_request }}
+			build_failure_grace_period_in_days = {{ .grace_period_days }}
+			block_download {
+				unscanned = {{ .block_unscanned }}
+				active = {{ .block_active }}
+			}
+		}
+	}
+
+	rule {
+		name = "{{ .rule_name_2 }}"
+		priority = 1
 		criteria {
 			cvss_range {
 				from = {{ .cvss_from }}


### PR DESCRIPTION
## Fix: Xray terraform provider will plan changes to policy rules on an existing state then fail to apply them with "Provider produced inconsistent result after apply" 

Fixes [JTFPR-371](https://jfrog-int.atlassian.net/browse/JTFPR-371)

### Issue Details

- **Type:** bug
- **Source:** JIRA
- **Jira:** [JTFPR-371](https://jfrog-int.atlassian.net/browse/JTFPR-371)

### Problem

Problem Description: When a customer wants to update their existing policies to include new rules, terraform might plan by making changes to the fields of existing rules. When terraform provider goes to apply, it will fail with errors like the below.
2026-07-29T15:01:19.1190329Z [31m│[0m [0m[1m[31mError: [0m[0m[1mProvider produced inconsistent result after apply[0m
2026-07-29T15:01:19.1191144Z [31m│[0m [0m
2026-07-29T15:01:19.1192022Z [31m│[0m [0m[0mWhen applying changes to ***_security_policy.block_cve_promotion, provider
2026-07-29T15:01:19.1193580Z [31m│[0m [0m"provider[\"registry.terraform.io/jfrog/***\"]" produced an unexpected new
2026-07-29T15:01:19.1194733Z [31m│[0m [0mvalue: .rule[7].name: was cty.StringVal("block-shai-hulud-4-***-ids-a"),
2026-07-29T15:01:19.1195786Z [31m│[0m [0mbut now cty.StringVal("block-marimo-less-than-0_23_0").
2026-07-29T15:01:19.1196524Z [31m│[0m [0m
2026-07-29T15:01:19.1197320Z [31m│[0m [0mThis is a bug in the provider, which should be reported in the provider's
2026-07-29T15:01:19.1198198Z [31m│[0m [0mown issue tracker.Expected Behavior: If a terraform run plans to update the existing policy rules, then those updates should be made successfully.
Reproduction: I have attached the customer’s terraform configuration with which this occurred which includes steps on how to run. They had initially opened the issue with slow planning but successful execution on 3.0.7. I had suggested an upg...

### Files Changed

- `pkg/xray/resource/policies.go`
- `pkg/xray/resource/resource_xray_security_policy_test.go`
- `CHANGELOG.md`

### Analysis

I now have a complete picture. Here's the analysis.

## ROOT CAUSE

The bug is in `fromAPIModel` in `pkg/xray/resource/policies.go`, lines 280–284:

```280:284:workspace/terraform-provider-xray/pkg/xray/resource/policies.go
	// Sort rules by priority to ensure consistent ordering between config and API response
	apiRules := *apiModel.Rules
	sort.Slice(apiRules, func(i, j int) bool {
		return apiRules[i].Priority < apiRules[j].Priority
	})
```

The `rule` block is declared as an **ordered `schema.ListNestedBlock`** (`policies.go:508`), and the model field is a `types.List` (`Rules types.List` at `policies.go:66`). For a List, Terraform enforces that the value written to state after apply is **positionally identical** (index-by-index) to what it planned.

During Create/Update the provider sends rules in the plan's declaration order, then does a GET and feeds the response into `fromAPIModel`, which **re-sorts the rules by `priority`** before writing state. When the practitioner's declaration order does not match ascending-priority order (the customer has ~8+ rules and they are clearly not authored in priority order), the sort reorders the list. The rule that the plan placed at `rule[7]` is now a different rule in state:

```
.rule[7].name: was cty.StringVal("block-shai-hulud-4-...-ids-a"),
               but now cty.StringVal("block-marimo-less-than-0_23_0").
```

That is exactly the "Provider produced inconsistent result after apply" contract violation. The sort's premise — "config is written in priority order, so sorting realigns it" — is false in general. Priority is not a unique ordering key (multiple rules can share a priority) and has no relationship to config declaration order.

Note: the existing `TestAccSecurityPolicy_multipleRules` test (line 205) did **not** catch this because it asserts with `TestCheckTypeSetElemNestedAttrs(fqrn, "rule.*", ...)` (set-membership, order-insensitive) instead of indexed `rule.0.name` / `rule.1.name` checks.

## FIX PLAN

### File: `pkg/xray/resource/policies.go`

**1. Replace the priority sort (lines 280–284) with plan/state-order realignment keyed by the unique rule name.**

The correct order to preserve is the order already present in the receiver `m.Rules`, which holds:
- Create → `plan.Rules` (config order) — `policies.go:800`
- Update → `plan.Rules` (config order) — `policies.go:938`
- Read → prior `state.Rules` (last-applied order) — `policies.go:860`
- Import → `null` → fall back to API order (no prior plan to be consistent with)

`m.Rules` is still the old value at this point because it isn't overwritten until line 332 (`m.Rules = rulesSet`), so we can read the desired order first. Rule names are guaranteed unique by `ValidateConfig` (`resource_xray_security_policy.go:782–802`), so name is a safe reordering key.

**2. Remove the now-unused `"sort"` import (line 6).**

This fixes the issue because the state list is rebuilt in the exact order Terraform planned, so `rule[i]` in state always matches `rule[i]` in the plan.

## CODE CHANGES

### `pkg/xray/resource/policies.go` — imports

```go
// Before:
import (
	"context"
	"net/http"
	"sort"
	"strings"
	...
)

// After:
import (
	"context"
	"net/http"
	"strings"
	...
)
```

### `pkg/xray/resource/policies.go` — `fromAPIModel` ordering

```go
// Before:
	// Sort rules by priority to ensure consistent ordering between config and API response
	apiRules := *apiModel.Rules
	sort.Slice(apiRules, func(i, j int) bool {
		return apiRules[i].Priority < apiRules[j].Priority
	})

	rules := lo.Map(
		apiRules,

// After:
	// The `rule` block is an ordered List, so the state written back after apply
	// must be positionally identical to the plan. The Xray API does not guarantee
	// it echoes rules back in the order they were sent, so realign the API
	// response to the order of the plan/prior-state rules, keyed by the unique
	// rule name. Sorting by priority is wrong: config order need not match
	// priority order, which caused "Provider produced inconsistent result after
	// apply" for policies whose rules are not authored in ascending-priority order.
	apiRules := orderRulesToState(*apiModel.Rules, m.Rules)

	rules := lo.Map(
		apiRules,
```

### `pkg/xray/resource/policies.go` — new helper (add near `fromAPIModel`)

```go
// orderRulesToState reorders the rules returned by the API to match the order of
// the rules already present in the Terraform plan/prior state, keyed by the
// unique rule name. The `rule` block is an ordered List, so this positional
// alignment is required to avoid "inconsistent result after apply" errors.
// If the order cannot be determined (import with no prior state, count mismatch,
// duplicate/absent names, or a rename), the API order is returned unchanged.
func orderRulesToState(apiRules []PolicyRuleAPIModel, stateRules types.List) []PolicyRuleAPIModel {
	if stateRules.IsNull() || stateRules.IsUnknown() {
		return apiRules
	}

	stateElems := stateRules.Elements()
	if len(stateElems) != len(apiRules) {
		return apiRules
	}

	byName := make(map[string]PolicyRuleAPIModel, len(apiRules))
	for _, rule := range apiRules {
		byName[rule.Name] = rule
	}
	if len(byName) != len(apiRules) {
		// Duplicate names in the API response; cannot reorder safely.
		return apiRules
	}

	ordered := make([]PolicyRuleAPIModel, 0, len(apiRules))
	for _, elem := range stateElems {
		obj, ok := elem.(types.Object)
		if !ok {
			return apiRules
		}
		nameAttr, ok := obj.Attributes()["name"].(types.String)
		if !ok || nameAttr.IsNull() || nameAttr.IsUnknown() {
			return apiRules
		}
		rule, ok := byName[nameAttr.ValueString()]
		if !ok {
			return apiRules
		}
		ordered = append(ordered, rule)
	}

	return ordered
}
```

**Minimal alternative** (if you want the smallest possible diff and trust that the Xray API echoes rules back in insertion order): simply delete the `sort.Slice` block and use `apiRules := *apiModel.Rules` unsorted. The name-keyed reorder above is the more defensive choice and is what I recommend, because it is correct regardless of the API's return order.

> Side note (not the reported bug, but related): `preserveFailPullRequest` (`policies.go:674`) and `extractFailPullRequestFromState` (`policies.go:687`) both match rules by **index** between plan order and API order. They are only correct if the API returns rules in plan order. If you adopt the minimal alternative, verify this holds; the name-keyed approach in `fromAPIModel` does not change their behavior but it's worth a regression check.

## TEST PLAN

Add an acceptance test in `resource_xray_security_policy_test.go` that specifically exercises declaration-order ≠ priority-order and asserts by **index** (not `rule.*`), which is what the current multi-rule test fails to do.

1. **`TestAccSecurityPolicy_ruleOrderNotByPriority` (reproduces the bug):**
   - Config with 3 rules where declaration order is inverse to priority, e.g. `rule[0].priority = 3`, `rule[1].priority = 1`, `rule[2].priority = 2`, each with a distinct `name`.
   - Assert with indexed checks so ordering is verified:

```go
resource.TestCheckResourceAttr(fqrn, "rule.#", "3"),
resource.TestCheckResourceAttr(fqrn, "rule.0.name", testData["rule_name_1"]),
resource.TestCheckResourceAttr(fqrn, "rule.0.priority", "3"),
resource.TestCheckResourceAttr(fqrn, "rule.1.name", testData["rule_name_2"]),
resource.TestCheckResourceAttr(fqrn, "rule.1.priority", "1"),
resource.TestCheckResourceAttr(fqrn, "rule.2.name", testData["rule_name_3"]),
resource.TestCheckResourceAttr(fqrn, "rule.2.priority", "2"),
```

   Before the fix this step fails at apply with "inconsistent result after apply"; after the fix it passes.

2. **Update step — insert a rule in the middle** (mirrors the customer scenario of "update existing policies to include new rules"): re-apply with a 4th rule inserted between existing rules and modified fields on existing rules; assert indexed order is preserved and apply succeeds. Add a follow-up `PlanOnly`/empty-plan step to prove no perpetual diff.

3. **Idempotency / refresh:** add `{ Config: ..., PlanOnly: true, ExpectNonEmptyPlan: false }` after create to confirm Read preserves order (state-order key path).

4. **Import:** `{ ResourceName: fqrn, ImportState: true, ImportStateVerify: true }` — exercises the `stateRules.IsNull()` fallback branch and confirms imported multi-rule policies don't drift on the next plan.

5. **Convert the existing `TestAccSecurityPolicy_multipleRules`** assertions from `TestCheckTypeSetElemNestedAttrs(fqrn, "rule.*", …)` to indexed `rule.0.*` / `rule.1.*` so ordering regressions are actually caught going forward.

## CHANGELOG ENTRY

```
BUG FIX: resource/xray_security_policy, resource/xray_license_policy, resource/xray_operational_risk_policy - Fix "Provider produced inconsistent result after apply" when updating policies whose rules are not declared in ascending-priority order. Rules are now kept in configuration order instead of being re-sorted by priority. (GH-NNN)
```

(The fix lives in shared `policies.go` `fromAPIModel`, so it applies to all three policy resources. Replace `GH-NNN` with the real issue number and use `bugfix/GH-NNN-policy-rule-order-inconsistent` as the branch per the skill's convention.)

### Changelog

```
## 3.1.14 (August 26, 2026)

BUG FIXES:

* Fix xray terraform provider will plan changes to policy rules on an existing state then fail to apply them with "Prov...

```

### Test Plan

- [ ] `go build ./...` passes
- [ ] Acceptance tests pass
- [ ] No state drift after apply + plan
- [ ] Import test verifies no diff

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data source for looking up Xray Curation conditions by exact name and retrieving their numeric ID.

* **Bug Fixes**
  * Fixed policy rule ordering when priorities differ from declaration order.
  * Prevented inconsistent plan/apply results and unnecessary changes when policy rules are reordered by the service.

* **Documentation**
  * Updated release notes for version 3.1.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->