### PR TITLE
fix: treat Release Bundle V2 names as unique per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
-## 3.1.14 (September 3, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.20, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
+## 3.1.14 (September 3, 2026).
 
 FEATURES:
 
 * data/xray_curation_condition: Add a new data source which looks up a built-in or custom Curation condition by its exact name (case-sensitive) and exposes its numeric `id`, so `xray_curation_policy.condition_id` no longer has to be hard-coded to a raw numeric ID. Issue: JTFPR-341 PR: [#452](https://github.com/jfrog/terraform-provider-xray/pull/452)
+
+BUG FIXES:
+
+* resource/xray_security_policy, resource/xray_license_policy: Fix blank `Unable to Create/Update Resource` error on `terraform apply` when a proxy or load balancer in front of Xray (e.g. a Google load balancer) rejects the read-back `GET` request. The provider was reusing the same HTTP request object for the create/update `POST`/`PUT` and the follow-up `GET`, so the `GET` was sent with the write's leftover JSON body and `Content-Type` header, which such proxies treat as malformed and reject with a non-JSON `400` response. The read-back now uses a fresh request without a body. Additionally, when the API (or an intermediate proxy) returns a non-JSON error response, the provider now surfaces the HTTP status code and raw response body instead of a blank error message. Issue: JTFPR-276
+* resource/xray_binary_manager_release_bundles_v2: Fix `Error: Duplicate Set Element` during plan when Release Bundles V2 with the same name exist in different projects. Release Bundle V2 names are unique per project, but the API returns them as `[<project-key>-release-bundles-v2]/<name>` and the provider stripped that prefix, collapsing bundles from different projects into duplicate set elements. Names are now scoped to the resource's `project_key` before being stored in `indexed_release_bundle_v2` and `non_indexed_release_bundle_v2`.
+
+NOTES:
+
+* resource/xray_binary_manager_release_bundles_v2: After upgrade, `indexed_release_bundle_v2` and `non_indexed_release_bundle_v2` only include Release Bundles V2 that belong to the resource's `project_key` (or the default scope when `project_key` is unset). The same bundle name in different projects is valid and requires a separate resource per `project_key`. If a default-scope resource previously listed project-scoped names, move those names to project-scoped resources and expect set membership diffs on the next `terraform plan`.
 
 ## 3.1.13 (Aug 21, 2026). Tested on JFrog Platform 11.6.1 (Artifactory 7.161.16, Xray 3.150.24, Catalog 1.44.0) with Terraform 1.15.8 and OpenTofu 1.12.5
 
@@ -17,7 +26,6 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * resource/xray_security_policy: Fix `Found Invalid Policy: All severities is not a valid severity in sast condition` when creating or updating a policy with `sast.min_severity = "All severities"`. Xray rejects that literal value in a `sast` condition and also rejects the field being omitted, so it is now sent as the API's `Unknown` sentinel and mapped back to `All severities` on read to avoid drift. Also accept the UI label `All Severities` (and other case variants) via case-insensitive validation and preserve the configured casing in state. Issue: [#445](https://github.com/jfrog/terraform-provider-xray/issues/445) PR: [#446](https://github.com/jfrog/terraform-provider-xray/pull/446)
-* resource/xray_security_policy, resource/xray_license_policy: Fix blank `Unable to Create/Update Resource` error on `terraform apply` when a proxy or load balancer in front of Xray (e.g. a Google load balancer) rejects the read-back `GET` request. The provider was reusing the same HTTP request object for the create/update `POST`/`PUT` and the follow-up `GET`, so the `GET` was sent with the write's leftover JSON body and `Content-Type` header, which such proxies treat as malformed and reject with a non-JSON `400` response. The read-back now uses a fresh request without a body. Additionally, when the API (or an intermediate proxy) returns a non-JSON error response, the provider now surfaces the HTTP status code and raw response body instead of a blank error message. Issue: JTFPR-276
 
 SECURITY:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 3, 2026).
+## 3.1.14 (September 3, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.20, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/docs/resources/binary_manager_release_bundles_v2.md
+++ b/docs/resources/binary_manager_release_bundles_v2.md
@@ -8,12 +8,29 @@ subcategory: "Binary Manager"
 
 Provides an Xray Binary Manager Release Bundles V2 Indexing configuration resource. See [Indexing Xray Resources](https://jfrog.com/help/r/jfrog-security-documentation/add-or-remove-resources-from-indexing) and [REST API](https://jfrog.com/help/r/xray-rest-apis/add-release-bundles-v2-indexing-configuration) for more details.
 
+~> Release Bundle V2 names are unique per project. The same name in two projects requires a separate resource with `project_key` for each project. A resource without `project_key` only manages default-scope bundles (`[release-bundles-v2]/<name>`), not project-scoped ones.
+
 ## Example Usage
 
 ```terraform
+# Default indexer (no project). Use this only for default-scope Release Bundles V2.
 resource "xray_binary_manager_release_bundles_v2" "my-indexed-release-bundles" {
-  id = "default"
+  id                        = "default"
   indexed_release_bundle_v2 = ["my-release-bundle-1", "my-release-bundle-2"]
+}
+
+# Release Bundle V2 names are unique per project. The same name in two projects
+# requires a separate resource with project_key for each project.
+resource "xray_binary_manager_release_bundles_v2" "project-a" {
+  id                        = "default"
+  project_key               = "project-a"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
+}
+
+resource "xray_binary_manager_release_bundles_v2" "project-b" {
+  id                        = "default"
+  project_key               = "project-b"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
 }
 ```
 

--- a/examples/resources/xray_binary_manager_release_bundles_v2/resource.tf
+++ b/examples/resources/xray_binary_manager_release_bundles_v2/resource.tf
@@ -1,4 +1,19 @@
+# Default indexer (no project). Use this only for default-scope Release Bundles V2.
 resource "xray_binary_manager_release_bundles_v2" "my-indexed-release-bundles" {
-  id = "default"
+  id                        = "default"
   indexed_release_bundle_v2 = ["my-release-bundle-1", "my-release-bundle-2"]
+}
+
+# Release Bundle V2 names are unique per project. The same name in two projects
+# requires a separate resource with project_key for each project.
+resource "xray_binary_manager_release_bundles_v2" "project-a" {
+  id                        = "default"
+  project_key               = "project-a"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
+}
+
+resource "xray_binary_manager_release_bundles_v2" "project-b" {
+  id                        = "default"
+  project_key               = "project-b"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
 }

--- a/pkg/xray/resource/resource_xray_binary_manager_release_bundle_v2.go
+++ b/pkg/xray/resource/resource_xray_binary_manager_release_bundle_v2.go
@@ -2,6 +2,7 @@ package xray
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
+	"github.com/samber/lo"
 )
 
 const BinaryManagerReleaseBundleV2Endpoint = "xray/api/v1/binMgr/{id}/release_bundle_v2"
@@ -58,40 +60,87 @@ func (m BinaryManagerReleaseBundlesV2ResourceModel) toAPIModel(ctx context.Conte
 	return
 }
 
-// stripReleaseBundleV2Prefix removes the "[repo-type]/" prefix from release bundle names
-// that the API returns. For example: "[release-bundles-v2]/bundle-name" -> "bundle-name"
-func stripReleaseBundleV2Prefix(name string) string {
-	if idx := strings.Index(name, "]/"); idx != -1 {
-		return name[idx+2:]
+// releaseBundleV2RepoKey returns the repository key holding Release Bundles V2 for
+// a project scope. Project bundles live in "<project-key>-release-bundles-v2", while
+// the default scope uses "release-bundles-v2".
+func releaseBundleV2RepoKey(projectKey string) string {
+	if projectKey == "" {
+		return "release-bundles-v2"
 	}
-	return name
+
+	return fmt.Sprintf("%s-release-bundles-v2", projectKey)
+}
+
+// SplitReleaseBundleV2Name splits a name returned by the API, e.g.
+// "[suriya-release-bundles-v2]/bundle-name", into its repository key and bundle name.
+// Names without the prefix yield an empty repository key.
+func SplitReleaseBundleV2Name(name string) (string, string) {
+	if strings.HasPrefix(name, "[") {
+		if idx := strings.Index(name, "]/"); idx != -1 {
+			return name[1:idx], name[idx+2:]
+		}
+	}
+
+	return "", name
+}
+
+// isDefaultScopeReleaseBundleV2Response reports whether every name belongs to the
+// default scope, i.e. carries no repository prefix or the default repository key.
+func isDefaultScopeReleaseBundleV2Response(names []string) bool {
+	defaultRepoKey := releaseBundleV2RepoKey("")
+
+	return lo.EveryBy(names, func(name string) bool {
+		nameRepoKey, _ := SplitReleaseBundleV2Name(name)
+		return nameRepoKey == "" || nameRepoKey == defaultRepoKey
+	})
+}
+
+// ReleaseBundleV2NamesFromAPI converts API names into bundle names for the given
+// project scope. Bundle names are unique per project, so identically named bundles
+// from other projects would otherwise collapse into duplicate set elements.
+func ReleaseBundleV2NamesFromAPI(names []string, projectKey string) []string {
+	repoKey := releaseBundleV2RepoKey(projectKey)
+
+	inScope := lo.Filter(names, func(name string, _ int) bool {
+		nameRepoKey, _ := SplitReleaseBundleV2Name(name)
+		return nameRepoKey == "" || nameRepoKey == repoKey
+	})
+
+	// Xray versions without Projects support on this endpoint ignore the projectKey
+	// query parameter and report every bundle under the default scope, so a
+	// project-scoped resource accepts those names rather than reading back an empty
+	// configuration. Names from other projects are never in scope.
+	if projectKey != "" && isDefaultScopeReleaseBundleV2Response(names) {
+		inScope = names
+	}
+
+	return lo.Uniq(
+		lo.Map(inScope, func(name string, _ int) string {
+			_, bundleName := SplitReleaseBundleV2Name(name)
+			return bundleName
+		}),
+	)
 }
 
 func (m *BinaryManagerReleaseBundlesV2ResourceModel) fromAPIModel(ctx context.Context, apiModel BinaryManagerReleaseBundlesV2APIModel, preserveIndexed bool) (ds diag.Diagnostics) {
 	m.ID = types.StringValue(apiModel.BinManagerID)
 
+	projectKey := m.ProjectKey.ValueString()
+
 	// Only update IndexedReleaseBundlesV2 from API during Read (not Create/Update)
 	// This avoids "inconsistent result after apply" errors when API returns
 	// different ordering or timing-delayed results
 	if !preserveIndexed {
-		// Strip the "[repo-type]/" prefix from each release bundle name
-		strippedIndexed := make([]string, len(apiModel.IndexedReleaseBundlesV2))
-		for i, name := range apiModel.IndexedReleaseBundlesV2 {
-			strippedIndexed[i] = stripReleaseBundleV2Prefix(name)
-		}
-		indexedReleaseBundlesV2, d := types.SetValueFrom(ctx, types.StringType, strippedIndexed)
+		indexed := ReleaseBundleV2NamesFromAPI(apiModel.IndexedReleaseBundlesV2, projectKey)
+		indexedReleaseBundlesV2, d := types.SetValueFrom(ctx, types.StringType, indexed)
 		if d != nil {
 			ds.Append(d...)
 		}
 		m.IndexedReleaseBundlesV2 = indexedReleaseBundlesV2
 	}
 
-	// Strip the "[repo-type]/" prefix from each non-indexed release bundle name
-	strippedNonIndexed := make([]string, len(apiModel.NonIndexedReleaseBundlesV2))
-	for i, name := range apiModel.NonIndexedReleaseBundlesV2 {
-		strippedNonIndexed[i] = stripReleaseBundleV2Prefix(name)
-	}
-	nonIndexedBuilds, d := types.SetValueFrom(ctx, types.StringType, strippedNonIndexed)
+	nonIndexed := ReleaseBundleV2NamesFromAPI(apiModel.NonIndexedReleaseBundlesV2, projectKey)
+	nonIndexedBuilds, d := types.SetValueFrom(ctx, types.StringType, nonIndexed)
 	if d != nil {
 		ds.Append(d...)
 	}

--- a/pkg/xray/resource/resource_xray_binary_manager_release_bundle_v2_test.go
+++ b/pkg/xray/resource/resource_xray_binary_manager_release_bundle_v2_test.go
@@ -1,6 +1,7 @@
 package xray_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-xray/v3/pkg/acctest"
+	xrayresource "github.com/jfrog/terraform-provider-xray/v3/pkg/xray/resource"
 	"github.com/samber/lo"
 )
 
@@ -268,21 +270,23 @@ func TestAccBinaryManagerReleaseBundlesV2_full(t *testing.T) {
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
+			var errs []error
+
 			if err := deleteReleaseBundleV2Version(t, releaseBundle1Name, ""); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			if err := deleteReleaseBundleV2Version(t, releaseBundle2Name, ""); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			if err := deleteKeyPair(t, keyPairName); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			acctest.DeleteRepo(t, repoName)
 
-			return nil
+			return errors.Join(errs...)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -382,23 +386,25 @@ func TestAccBinaryManagerReleaseBundlesV2_project_full(t *testing.T) {
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
+			var errs []error
+
 			if err := deleteReleaseBundleV2Version(t, releaseBundle1Name, projectKey); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			if err := deleteReleaseBundleV2Version(t, releaseBundle2Name, projectKey); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			if err := deleteKeyPair(t, keyPairName); err != nil {
-				return nil
+				errs = append(errs, err)
 			}
 
 			acctest.DeleteProject(t, projectKey)
 
 			acctest.DeleteRepo(t, repoName)
 
-			return nil
+			return errors.Join(errs...)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -426,6 +432,112 @@ func TestAccBinaryManagerReleaseBundlesV2_project_full(t *testing.T) {
 				ImportStateId:                        fmt.Sprintf("%s:%s", resourceName, projectKey),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "id",
+			},
+		},
+	})
+}
+
+func TestAccBinaryManagerReleaseBundlesV2_same_name_different_projects(t *testing.T) {
+	_, fqrn1, resourceName1 := testutil.MkNames("test-bin-mgr-release-bundles-v2", "xray_binary_manager_release_bundles_v2")
+	_, fqrn2, resourceName2 := testutil.MkNames("test-bin-mgr-release-bundles-v2", "xray_binary_manager_release_bundles_v2")
+
+	projectKey1 := lo.RandomString(6, lo.LowerCaseLettersCharset)
+	projectKey2 := lo.RandomString(6, lo.LowerCaseLettersCharset)
+
+	keyPairName := fmt.Sprintf("test-keypair-%d", testutil.RandomInt())
+
+	repoName := fmt.Sprintf("test-repo-%d", testutil.RandomInt())
+
+	// Release Bundle V2 names are scoped per project, so the same name in two
+	// projects must not be treated as a duplicate set element.
+	releaseBundleName := fmt.Sprintf("test-release-bundles-v2-%d", testutil.RandomInt())
+
+	const template = `
+		resource "xray_binary_manager_release_bundles_v2" "{{ .name1 }}" {
+			id = "default"
+			project_key = "{{ .projectKey1 }}"
+			indexed_release_bundle_v2 = ["{{ .releaseBundleName }}"]
+		}
+
+		resource "xray_binary_manager_release_bundles_v2" "{{ .name2 }}" {
+			id = "default"
+			project_key = "{{ .projectKey2 }}"
+			indexed_release_bundle_v2 = ["{{ .releaseBundleName }}"]
+		}
+	`
+
+	testData := map[string]string{
+		"name1":             resourceName1,
+		"name2":             resourceName2,
+		"projectKey1":       projectKey1,
+		"projectKey2":       projectKey2,
+		"releaseBundleName": releaseBundleName,
+	}
+
+	config := util.ExecuteTemplate("TestAccBinaryManagerReleaseBundlesV2_same_name_different_projects", template, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.CreateRepos(t, repoName, "local", "", "maven")
+
+			path, sha256, err := uploadTestFile(t, repoName)
+			if err != nil {
+				t.Fatalf("failed to upload file: %s", err)
+			}
+
+			acctest.CreateProject(t, projectKey1)
+			acctest.CreateProject(t, projectKey2)
+
+			if err := createKeyPair(t, keyPairName); err != nil {
+				t.Fatalf("failed to create key pair: %s", err)
+			}
+
+			if err := createReleaseBundleV2(t, releaseBundleName, keyPairName, repoName, projectKey1, path, sha256); err != nil {
+				t.Fatalf("failed to create release bundle: %s", err)
+			}
+
+			if err := createReleaseBundleV2(t, releaseBundleName, keyPairName, repoName, projectKey2, path, sha256); err != nil {
+				t.Fatalf("failed to create release bundle: %s", err)
+			}
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: func(*terraform.State) error {
+			var errs []error
+
+			if err := deleteReleaseBundleV2Version(t, releaseBundleName, projectKey1); err != nil {
+				errs = append(errs, err)
+			}
+
+			if err := deleteReleaseBundleV2Version(t, releaseBundleName, projectKey2); err != nil {
+				errs = append(errs, err)
+			}
+
+			if err := deleteKeyPair(t, keyPairName); err != nil {
+				errs = append(errs, err)
+			}
+
+			acctest.DeleteProject(t, projectKey1)
+			acctest.DeleteProject(t, projectKey2)
+
+			acctest.DeleteRepo(t, repoName)
+
+			return errors.Join(errs...)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn1, "project_key", projectKey1),
+					resource.TestCheckResourceAttr(fqrn1, "indexed_release_bundle_v2.#", "1"),
+					resource.TestCheckResourceAttr(fqrn1, "indexed_release_bundle_v2.0", releaseBundleName),
+					resource.TestCheckResourceAttr(fqrn2, "project_key", projectKey2),
+					resource.TestCheckResourceAttr(fqrn2, "indexed_release_bundle_v2.#", "1"),
+					resource.TestCheckResourceAttr(fqrn2, "indexed_release_bundle_v2.0", releaseBundleName),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
 			},
 		},
 	})
@@ -461,6 +573,116 @@ func TestAccBinaryManagerReleaseBundlesV2_invalid_patterns(t *testing.T) {
 					},
 				},
 			})
+		})
+	}
+}
+
+func TestReleaseBundleV2NamesFromAPI(t *testing.T) {
+	testCases := []struct {
+		name       string
+		apiNames   []string
+		projectKey string
+		expected   []string
+	}{
+		{
+			name:       "scopes names to the project",
+			apiNames:   []string{"[suriya-release-bundles-v2]/demo1", "[suriyams-release-bundles-v2]/demo1"},
+			projectKey: "suriya",
+			expected:   []string{"demo1"},
+		},
+		{
+			name:       "scopes names to the other project",
+			apiNames:   []string{"[suriya-release-bundles-v2]/demo1", "[suriyams-release-bundles-v2]/demo2"},
+			projectKey: "suriyams",
+			expected:   []string{"demo2"},
+		},
+		{
+			name:       "excludes names from foreign project repositories",
+			apiNames:   []string{"[suriya-release-bundles-v2]/demo1", "[suriyams-release-bundles-v2]/demo1"},
+			projectKey: "",
+			expected:   []string{},
+		},
+		{
+			name:       "keeps default scope names",
+			apiNames:   []string{"[release-bundles-v2]/demo1", "[suriya-release-bundles-v2]/demo2"},
+			projectKey: "",
+			expected:   []string{"demo1"},
+		},
+		{
+			name:       "keeps names without a repository prefix",
+			apiNames:   []string{"demo1", "demo2"},
+			projectKey: "suriya",
+			expected:   []string{"demo1", "demo2"},
+		},
+		{
+			name:       "handles empty response",
+			apiNames:   []string{},
+			projectKey: "suriya",
+			expected:   []string{},
+		},
+		{
+			name:       "preserves empty result for only foreign project entries",
+			apiNames:   []string{"[other-release-bundles-v2]/demo1", "[suriyams-release-bundles-v2]/demo2"},
+			projectKey: "suriya",
+			expected:   []string{},
+		},
+		{
+			name:       "falls back to all names for default-scoped API response",
+			apiNames:   []string{"[release-bundles-v2]/demo1", "demo2"},
+			projectKey: "suriya",
+			expected:   []string{"demo1", "demo2"},
+		},
+		{
+			name:       "does not fall back for mixed default and foreign entries",
+			apiNames:   []string{"[release-bundles-v2]/demo1", "[other-release-bundles-v2]/demo2"},
+			projectKey: "suriya",
+			expected:   []string{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := xrayresource.ReleaseBundleV2NamesFromAPI(testCase.apiNames, testCase.projectKey)
+
+			if len(actual) != len(testCase.expected) {
+				t.Fatalf("expected %v, got %v", testCase.expected, actual)
+			}
+
+			for _, expectedName := range testCase.expected {
+				if !lo.Contains(actual, expectedName) {
+					t.Errorf("expected %v to contain %q", actual, expectedName)
+				}
+			}
+
+			if len(lo.Uniq(actual)) != len(actual) {
+				t.Errorf("expected unique names, got %v", actual)
+			}
+		})
+	}
+}
+
+func TestSplitReleaseBundleV2Name(t *testing.T) {
+	testCases := []struct {
+		apiName         string
+		expectedRepoKey string
+		expectedName    string
+	}{
+		{apiName: "[suriya-release-bundles-v2]/demo1", expectedRepoKey: "suriya-release-bundles-v2", expectedName: "demo1"},
+		{apiName: "[release-bundles-v2]/demo1", expectedRepoKey: "release-bundles-v2", expectedName: "demo1"},
+		{apiName: "demo1", expectedRepoKey: "", expectedName: "demo1"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.apiName, func(t *testing.T) {
+			repoKey, name := xrayresource.SplitReleaseBundleV2Name(testCase.apiName)
+
+			if repoKey != testCase.expectedRepoKey {
+				t.Errorf("expected repository key %q, got %q", testCase.expectedRepoKey, repoKey)
+			}
+
+			if name != testCase.expectedName {
+				t.Errorf("expected name %q, got %q", testCase.expectedName, name)
+			}
 		})
 	}
 }

--- a/sample.tf
+++ b/sample.tf
@@ -655,3 +655,23 @@ resource "xray_ignore_rule" "ignore-rule-2590579" {
       file_path  = ["/path/to/file"]
   }
 }
+
+# Default indexer (no project). Use this only for default-scope Release Bundles V2.
+resource "xray_binary_manager_release_bundles_v2" "my-indexed-release-bundles" {
+  id                        = "default"
+  indexed_release_bundle_v2 = ["my-release-bundle-1", "my-release-bundle-2"]
+}
+
+# Same Release Bundle V2 name is valid in different projects. Use one resource
+# per project_key; do not list both on the default resource above.
+resource "xray_binary_manager_release_bundles_v2" "project-a" {
+  id                        = "default"
+  project_key               = "project-a"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
+}
+
+resource "xray_binary_manager_release_bundles_v2" "project-b" {
+  id                        = "default"
+  project_key               = "project-b"
+  indexed_release_bundle_v2 = ["my-release-bundle"]
+}

--- a/templates/resources/binary_manager_release_bundles_v2.md.tmpl
+++ b/templates/resources/binary_manager_release_bundles_v2.md.tmpl
@@ -8,6 +8,8 @@ subcategory: "Binary Manager"
 
 Provides an Xray Binary Manager Release Bundles V2 Indexing configuration resource. See [Indexing Xray Resources](https://jfrog.com/help/r/jfrog-security-documentation/add-or-remove-resources-from-indexing) and [REST API](https://jfrog.com/help/r/xray-rest-apis/add-release-bundles-v2-indexing-configuration) for more details.
 
+~> Release Bundle V2 names are unique per project. The same name in two projects requires a separate resource with `project_key` for each project. A resource without `project_key` only manages default-scope bundles (`[release-bundles-v2]/<name>`), not project-scoped ones.
+
 ## Example Usage
 
 {{tffile "examples/resources/xray_binary_manager_release_bundles_v2/resource.tf"}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Release Bundle V2 entries when identically named bundles exist in different projects.
  * Prevented perpetual plan differences for project-scoped resources with overlapping bundle names.
  * Preserved correct handling of project-specific, unscoped, and default-scope bundles.

* **Tests**
  * Added unit and acceptance coverage for project-scoped names, duplicate removal, and stable planning.

* **Documentation**
  * Updated configuration examples and resource documentation with project-scoped indexing guidance.
  * Updated the 3.1.15 changelog with platform and tooling test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->