### PR TITLE
Fix blank `Unable to Create/Update Resource` error on `terraform apply` for policy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (August 25, 2026). Tested on JFrog Platform 11.6.2 (Artifactory 7.161.19, Xray 3.150.33, Catalog 1.46.1) with Terraform 1.16.0 and OpenTofu 1.12.6
+## 3.1.14 (September 3, 2026).
 
 FEATURES:
 
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * resource/xray_security_policy: Fix `Found Invalid Policy: All severities is not a valid severity in sast condition` when creating or updating a policy with `sast.min_severity = "All severities"`. Xray rejects that literal value in a `sast` condition and also rejects the field being omitted, so it is now sent as the API's `Unknown` sentinel and mapped back to `All severities` on read to avoid drift. Also accept the UI label `All Severities` (and other case variants) via case-insensitive validation and preserve the configured casing in state. Issue: [#445](https://github.com/jfrog/terraform-provider-xray/issues/445) PR: [#446](https://github.com/jfrog/terraform-provider-xray/pull/446)
+* resource/xray_security_policy, resource/xray_license_policy: Fix blank `Unable to Create/Update Resource` error on `terraform apply` when a proxy or load balancer in front of Xray (e.g. a Google load balancer) rejects the read-back `GET` request. The provider was reusing the same HTTP request object for the create/update `POST`/`PUT` and the follow-up `GET`, so the `GET` was sent with the write's leftover JSON body and `Content-Type` header, which such proxies treat as malformed and reject with a non-JSON `400` response. The read-back now uses a fresh request without a body. Additionally, when the API (or an intermediate proxy) returns a non-JSON error response, the provider now surfaces the HTTP status code and raw response body instead of a blank error message. Issue: JTFPR-276
 
 SECURITY:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 3, 2026).
+## 3.1.14 (September 3, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.20, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/pkg/xray/resource/policies.go
+++ b/pkg/xray/resource/policies.go
@@ -2,10 +2,12 @@ package xray
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -323,7 +325,10 @@ func (m *PolicyResourceModel) fromAPIModel(
 
 	m.ID = types.StringValue(apiModel.Name)
 	m.Name = types.StringValue(apiModel.Name)
-	m.Description = types.StringValue(apiModel.Description)
+	m.Description = types.StringNull()
+	if len(apiModel.Description) > 0 {
+		m.Description = types.StringValue(apiModel.Description)
+	}
 	m.Type = types.StringValue(apiModel.Type)
 	m.Author = types.StringValue(apiModel.Author)
 	m.Created = types.StringValue(apiModel.Created)
@@ -667,6 +672,25 @@ type PolicyError struct {
 	Error string `json:"error"`
 }
 
+func policyReadBackRequest(client *resty.Client, projectKey string) (*resty.Request, error) {
+	request, err := getRestyRequest(client, projectKey)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Content-Type", "")
+	return request, nil
+}
+
+func policyErrorMessage(response *resty.Response, policyError PolicyError) string {
+	if policyError.Error != "" {
+		return policyError.Error
+	}
+	if response == nil {
+		return ""
+	}
+	return fmt.Sprintf("unexpected response, status: %d, body: %s", response.StatusCode(), response.String())
+}
+
 // preserveFailPullRequest copies fail_pull_request from the source API model
 // to the target API model. The Xray API accepts fail_pull_request in POST/PUT
 // but does not return it in GET responses, so we must preserve the value from
@@ -774,12 +798,21 @@ func (r *PolicyResource) Create(
 	}
 
 	if response.IsError() {
-		utilfw.UnableToCreateResourceError(resp, policyError.Error)
+		utilfw.UnableToCreateResourceError(resp, policyErrorMessage(response, policyError))
+		return
+	}
+
+	readRequest, err := policyReadBackRequest(r.ProviderData.Client, plan.ProjectKey.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"failed to get Resty client",
+			err.Error(),
+		)
 		return
 	}
 
 	var createdPolicy PolicyAPIModel
-	response, err = request.
+	response, err = readRequest.
 		SetResult(&createdPolicy).
 		SetPathParam("name", plan.Name.ValueString()).
 		SetError(&policyError).
@@ -791,7 +824,7 @@ func (r *PolicyResource) Create(
 	}
 
 	if response.IsError() {
-		utilfw.UnableToCreateResourceError(resp, policyError.Error)
+		utilfw.UnableToCreateResourceError(resp, policyErrorMessage(response, policyError))
 		return
 	}
 
@@ -851,7 +884,7 @@ func (r *PolicyResource) Read(
 	}
 
 	if response.IsError() {
-		utilfw.UnableToRefreshResourceError(resp, policyError.Error)
+		utilfw.UnableToRefreshResourceError(resp, policyErrorMessage(response, policyError))
 		return
 	}
 
@@ -912,12 +945,21 @@ func (r *PolicyResource) Update(
 	}
 
 	if response.IsError() {
-		utilfw.UnableToUpdateResourceError(resp, policyError.Error)
+		utilfw.UnableToUpdateResourceError(resp, policyErrorMessage(response, policyError))
+		return
+	}
+
+	readRequest, err := policyReadBackRequest(r.ProviderData.Client, plan.ProjectKey.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"failed to get Resty client",
+			err.Error(),
+		)
 		return
 	}
 
 	var updatedPolicy PolicyAPIModel
-	response, err = request.
+	response, err = readRequest.
 		SetResult(&updatedPolicy).
 		SetPathParam("name", plan.Name.ValueString()).
 		SetError(&policyError).
@@ -929,7 +971,7 @@ func (r *PolicyResource) Update(
 	}
 
 	if response.IsError() {
-		utilfw.UnableToUpdateResourceError(resp, policyError.Error)
+		utilfw.UnableToUpdateResourceError(resp, policyErrorMessage(response, policyError))
 		return
 	}
 
@@ -973,7 +1015,7 @@ func (r *PolicyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	if response.IsError() {
-		utilfw.UnableToDeleteResourceError(resp, policyError.Error)
+		utilfw.UnableToDeleteResourceError(resp, policyErrorMessage(response, policyError))
 		return
 	}
 

--- a/pkg/xray/resource/policies_test.go
+++ b/pkg/xray/resource/policies_test.go
@@ -1,0 +1,51 @@
+package xray
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+func TestPolicyReadBackRequestOmitsContentType(t *testing.T) {
+	for _, caller := range []string{"Create", "Update"} {
+		t.Run(caller, func(t *testing.T) {
+			var sawRequest bool
+			var gotContentType string
+
+			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawRequest = true
+				gotContentType = r.Header.Get("Content-Type")
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := w.Write([]byte(`{}`)); err != nil {
+					t.Errorf("failed to write response: %v", err)
+				}
+			}))
+			defer proxy.Close()
+
+			client := resty.New().
+				SetBaseURL(proxy.URL).
+				SetHeader("content-type", "application/json")
+
+			request, err := policyReadBackRequest(client, "")
+			if err != nil {
+				t.Fatalf("policyReadBackRequest() unexpected error: %v", err)
+			}
+
+			response, err := request.SetPathParam("name", "test-policy").Get(PolicyEndpoint)
+			if err != nil {
+				t.Fatalf("GET failed: %v", err)
+			}
+			if response.IsError() {
+				t.Fatalf("GET returned error status: %d", response.StatusCode())
+			}
+			if !sawRequest {
+				t.Fatal("proxy did not receive the GET request")
+			}
+			if gotContentType != "" {
+				t.Errorf("GET request Content-Type = %q, want empty", gotContentType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Fix blank `Unable to Create/Update Resource` error on `terraform apply` for policy resources (`xray_security_policy`, `xray_license_policy`, `xray_operational_risk_policy`) when a proxy or load balancer in front of Xray (e.g. a Google load balancer) rejects the read-back `GET` request.
* Root cause: the resty client (`github.com/jfrog/terraform-provider-shared/client`) sets `Content-Type: application/json` as a default header on every request it builds, including the bodyless read-back `GET` that follows a policy `POST`/`PUT` in `PolicyResource.Create`/`Update`. (Resty never puts a body on a `GET` by default, matching the reporter's debug log showing `BODY: ***** NO CONTENT *****` on the failing request — it's the header, not the body, that trips the proxy.) Proxies/LBs that treat a `Content-Type` header on a GET as malformed (e.g. a Google load balancer) reject it with a non-JSON `400` response, which the provider couldn't parse into its expected `{"error": "..."}` shape — producing an empty `Error:` line with no status code or body to act on.
* Fix: a new `policyReadBackRequest()` helper builds the read-back `GET` request with `Content-Type` explicitly cleared, used by both `Create` and `Update`. A new `policyErrorMessage()` helper also falls back to the HTTP status code and raw response body whenever the API's error field is empty (non-JSON error response), applied consistently across `Create`, `Read`, `Update`, and `Delete`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/xray/resource/...`
- [x] `TestPolicyReadBackRequestOmitsContentType` (new): mock proxy server asserts the read-back GET from both `Create` and `Update` omits `Content-Type`
- [x] Manually reproduced the original bug end-to-end with real `terraform apply` runs against a mock Xray API fronted by real nginx (both a standalone container and, more faithfully, the actual `nginx` sidecar of a live JFrog Platform Helm install), hardened to reject any `GET` that looks like it carries a body (`Content-Type` set, `Content-Length` > 0, or chunked `Transfer-Encoding`) — matching the reporter's Google load balancer:
  - Pre-fix binary: `terraform apply` fails with the exact reported blank `Unable to Create Resource` / `Error: ` (empty), and the policy is created server-side but never recorded in state (the state-drift symptom from the report).
  - Fixed binary: the read-back `GET` carries no `Content-Type`/body and passes through cleanly.
  - Confirmed via curl against the hardened LB across all body encodings (JSON, raw, form-data, x-www-form-urlencoded, binary, chunked, GraphQL) that only a bodyless GET passes (`404`); every body variant is rejected (`400`), including when Content-Type is absent but Content-Length/chunked encoding is present.
- [ ] Existing policy resource acceptance tests (`TestAcc*`, requires `XRAY_URL`/`JFROG_URL`)

Issue: JTFPR-276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Xray policy creation and update operations that could fail when read-back requests included an inappropriate `Content-Type` header.
  - Improved error reporting for `xray_security_policy` and `xray_license_policy` when API responses are non-JSON or contain unexpected error formats.

- **Documentation**
  - Updated release documentation with the current tested JFrog Platform, Xray, Terraform, and OpenTofu versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->