### PR TITLE
fix: [terraform-provider-xray] xray_curation_policy should support excluding user groups (GH#434)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,12 @@ builds:
     - goos: windows
       goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
+snapshot:
+  # `make install` moves dist/<target>/terraform-provider-xray_v${NEXT_VERSION} into the
+  # local plugin mirror, so a snapshot build has to be named after NEXT_VERSION. The
+  # default template derives the version from the git tag, which is the not-yet-created
+  # release tag and resolves to 0.0.0-SNAPSHOT-none.
+  version_template: '{{ envOrDefault "NEXT_VERSION" "0.0.0" }}'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
-* resource/xray_curation_policy: Add `group_exclude` and `group_include` attributes so JFrog Access user groups can be excluded from, or included in, a Curation policy's scope. Issue: [#434](https://github.com/jfrog/terraform-provider-xray/issues/434) PR: [#459](https://github.com/jfrog/terraform-provider-xray/pull/459)
+* resource/xray_curation_policy: Add `group_exclude` and `group_include` attributes so JFrog Access user groups can be excluded from, or included in, a Curation policy's scope. Group scope is resolved per requesting user and is only enforced on cached packages, so it requires `block_from_cache` to be set to `true`. Issue: [#434](https://github.com/jfrog/terraform-provider-xray/issues/434) PR: [#459](https://github.com/jfrog/terraform-provider-xray/pull/459)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 8, 2026). Tested on JFrog Platform 11.6.5 (Artifactory 7.161.26, Xray 3.150.37, Catalog 1.46.1) with Terraform 1.16.2 and OpenTofu 1.12.6
+## 3.1.14 (September 8, 2026). Tested on JFrog Platform 11.6.5 (Artifactory 7.161.26, Xray 3.150.37, Catalog 1.46.1). Tested on JFrog Platform 11.6.5 (Artifactory 7.161.26, Xray 3.150.37, Catalog 1.46.1) with Terraform 1.16.2 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.14 (September 8, 2026)
+## 3.1.14 (September 8, 2026). Tested on JFrog Platform 11.6.5 (Artifactory 7.161.26, Xray 3.150.37, Catalog 1.46.1) with Terraform 1.16.2 and OpenTofu 1.12.6
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 3.1.14 (September 3, 2026). Tested on JFrog Platform 11.6.3 (Artifactory 7.161.20, Xray 3.150.34, Catalog 1.46.1) with Terraform 1.16.1 and OpenTofu 1.12.6
+## 3.1.14 (September 8, 2026)
 
 FEATURES:
 
 * data/xray_curation_condition: Add a new data source which looks up a built-in or custom Curation condition by its exact name (case-sensitive) and exposes its numeric `id`, so `xray_curation_policy.condition_id` no longer has to be hard-coded to a raw numeric ID. Issue: JTFPR-341 PR: [#452](https://github.com/jfrog/terraform-provider-xray/pull/452)
+
+IMPROVEMENTS:
+
+* resource/xray_curation_policy: Add `group_exclude` and `group_include` attributes so JFrog Access user groups can be excluded from, or included in, a Curation policy's scope. Issue: [#434](https://github.com/jfrog/terraform-provider-xray/issues/434) PR: [#459](https://github.com/jfrog/terraform-provider-xray/pull/459)
 
 BUG FIXES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-${PRODUCT}@v${VERSION}
 
 build: fmt
-	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
+	NEXT_VERSION=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
 
 test:
 	@echo "==> Starting unit tests"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,8 +15,14 @@ endif
 PKG_NAME=pkg/xray
 # if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
 PKG_VERSION_PATH=github.com/jfrog/terraform-provider-${PRODUCT}/${PKG_NAME}
-VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
-NEXT_VERSION := $(shell echo ${VERSION}| awk -F '.' '{print $$1 "." $$2 "." $$3 +1 }' )
+VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/^v\([0-9][0-9]*\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\)$$/\1.\2.\3/p')
+# awk would print "..1" if VERSION is empty (no vX.Y.Z tag). Leave NEXT_VERSION
+# empty in that case so goreleaser's envOrDefault falls back to 0.0.0.
+ifeq ($(strip $(VERSION)),)
+NEXT_VERSION :=
+else
+NEXT_VERSION := $(shell echo $(VERSION) | awk -F. '{print $$1 "." $$2 "." $$3 + 1}')
+endif
 
 TERRAFORM_CLI?=terraform
 
@@ -48,7 +54,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-${PRODUCT}@v${VERSION}
 
 build: fmt
-	NEXT_VERSION=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
+	$(if $(NEXT_VERSION),NEXT_VERSION=$(NEXT_VERSION) )goreleaser build --single-target --clean --snapshot
 
 test:
 	@echo "==> Starting unit tests"

--- a/docs/resources/curation_policy.md
+++ b/docs/resources/curation_policy.md
@@ -283,6 +283,8 @@ resource "xray_curation_policy" "example_federation_pkg_types" {
 
 - `block_from_cache` (Boolean) When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.
 - `decision_owners` (Set of String) List of JFrog Access groups used by waiver_request_config=manual
+- `group_exclude` (Set of String) List of user groups to exclude from the policy scope.
+- `group_include` (Set of String) List of user groups to include in the policy scope.
 - `label_waivers` (Attributes Set) List of label waivers. (see [below for nested schema](#nestedatt--label_waivers))
 - `notify_emails` (Set of String) List of email addresses that receive notifications when the policy causes a package to be blocked.
 - `pkg_types_include` (Set of String) Used with scope: pkg_types. List of package types to include.

--- a/docs/resources/curation_policy.md
+++ b/docs/resources/curation_policy.md
@@ -283,8 +283,8 @@ resource "xray_curation_policy" "example_federation_pkg_types" {
 
 - `block_from_cache` (Boolean) When true, the policy also blocks packages served from Artifactory's cache. Defaults to false.
 - `decision_owners` (Set of String) List of JFrog Access groups used by waiver_request_config=manual
-- `group_exclude` (Set of String) List of user groups to exclude from the policy scope.
-- `group_include` (Set of String) List of user groups to include in the policy scope.
+- `group_exclude` (Set of String) List of user groups to exclude from the policy scope. Requires block_from_cache to be set to true.
+- `group_include` (Set of String) List of user groups to include in the policy scope. Requires block_from_cache to be set to true.
 - `label_waivers` (Attributes Set) List of label waivers. (see [below for nested schema](#nestedatt--label_waivers))
 - `notify_emails` (Set of String) List of email addresses that receive notifications when the policy causes a package to be blocked.
 - `pkg_types_include` (Set of String) Used with scope: pkg_types. List of package types to include.

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -304,6 +304,8 @@ type CurationPolicyResourceModel struct {
 	NotifyEmails        types.Set    `tfsdk:"notify_emails"`
 	WaiverRequestConfig types.String `tfsdk:"waiver_request_config"`
 	DecisionOwners      types.Set    `tfsdk:"decision_owners"`
+	GroupExclude        types.Set    `tfsdk:"group_exclude"`
+	GroupInclude        types.Set    `tfsdk:"group_include"`
 	BlockFromCache      types.Bool   `tfsdk:"block_from_cache"`
 	ShareWithFederation types.Bool   `tfsdk:"share_with_federation"`
 }
@@ -348,6 +350,8 @@ type CurationPolicyAPIModel struct {
 	NotifyEmails        []string                `json:"notify_emails,omitempty"`
 	WaiverRequestConfig string                  `json:"waiver_request_config,omitempty"`
 	DecisionOwners      []string                `json:"decision_owners,omitempty"`
+	GroupExclude        []string                `json:"group_exclude,omitempty"`
+	GroupInclude        []string                `json:"group_include,omitempty"`
 	BlockFromCache      bool                    `json:"block_from_cache"`
 	ShareWithFederation bool                    `json:"share_with_federation"`
 }
@@ -487,6 +491,16 @@ func (r *CurationPolicyResource) Schema(ctx context.Context, req resource.Schema
 				ElementType: types.StringType,
 				Description: "List of JFrog Access groups used by waiver_request_config=manual",
 			},
+			"group_exclude": schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "List of user groups to exclude from the policy scope.",
+			},
+			"group_include": schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "List of user groups to include in the policy scope.",
+			},
 			"block_from_cache": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -586,6 +600,26 @@ func (r *CurationPolicyResource) toAPIModel(ctx context.Context, plan CurationPo
 			return diags
 		}
 		policy.DecisionOwners = decisionOwners
+	}
+
+	// Convert group_exclude
+	if !plan.GroupExclude.IsNull() {
+		var groupExclude []string
+		diags := plan.GroupExclude.ElementsAs(ctx, &groupExclude, false)
+		if diags.HasError() {
+			return diags
+		}
+		policy.GroupExclude = groupExclude
+	}
+
+	// Convert group_include
+	if !plan.GroupInclude.IsNull() {
+		var groupInclude []string
+		diags := plan.GroupInclude.ElementsAs(ctx, &groupInclude, false)
+		if diags.HasError() {
+			return diags
+		}
+		policy.GroupInclude = groupInclude
 	}
 
 	// Convert waivers
@@ -723,6 +757,30 @@ func (r *CurationPolicyResource) fromAPIModel(ctx context.Context, policy Curati
 			return diags
 		}
 		plan.DecisionOwners = ownersSet
+	}
+
+	if len(policy.GroupExclude) > 0 {
+		groups := make([]attr.Value, len(policy.GroupExclude))
+		for i, group := range policy.GroupExclude {
+			groups[i] = types.StringValue(group)
+		}
+		groupsSet, diags := types.SetValue(types.StringType, groups)
+		if diags.HasError() {
+			return diags
+		}
+		plan.GroupExclude = groupsSet
+	}
+
+	if len(policy.GroupInclude) > 0 {
+		groups := make([]attr.Value, len(policy.GroupInclude))
+		for i, group := range policy.GroupInclude {
+			groups[i] = types.StringValue(group)
+		}
+		groupsSet, diags := types.SetValue(types.StringType, groups)
+		if diags.HasError() {
+			return diags
+		}
+		plan.GroupInclude = groupsSet
 	}
 
 	// Convert waivers from API to Terraform model (only if present)

--- a/pkg/xray/resource/resource_xray_curation_policy.go
+++ b/pkg/xray/resource/resource_xray_curation_policy.go
@@ -494,12 +494,12 @@ func (r *CurationPolicyResource) Schema(ctx context.Context, req resource.Schema
 			"group_exclude": schema.SetAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "List of user groups to exclude from the policy scope.",
+				Description: "List of user groups to exclude from the policy scope. Requires block_from_cache to be set to true.",
 			},
 			"group_include": schema.SetAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "List of user groups to include in the policy scope.",
+				Description: "List of user groups to include in the policy scope. Requires block_from_cache to be set to true.",
 			},
 			"block_from_cache": schema.BoolAttribute{
 				Optional:    true,

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -499,6 +499,105 @@ func TestAccCurationPolicy_AllRepos_Manual_DecisionOwners(t *testing.T) {
 	})
 }
 
+// Returns a policy configuration for the group scope tests, where groupAttr is
+// the group_exclude or group_include attribute under test.
+func createGroupScopePolicy(name string, conditionName string, groupAttr string) string {
+	return createMaturityCondition(conditionName) + fmt.Sprintf(`
+		resource "xray_curation_policy" "%s" {
+			name          = "%s"
+			condition_id  = xray_custom_curation_condition.%s.id
+			scope         = "all_repos"
+			policy_action = "block"
+			waiver_request_config = "forbidden"
+			%s
+		}
+	`, name, name, conditionName, groupAttr)
+}
+
+// Test all_repos scope with user groups excluded from the policy scope (GH#434)
+func TestAccCurationPolicy_AllRepos_GroupExclude(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-all-repos-group-exclude", "xray_curation_policy")
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	sharedRepoConfig := getSharedRepoConfig()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create shared repositories and verify they exist
+				Config: sharedRepoConfig,
+				Check:  resource.ComposeTestCheckFunc(getSharedRepoVerification()...),
+			},
+			{
+				// Step 2: Create the policy with a user group excluded from its scope
+				Config: sharedRepoConfig +
+					createGroupScopePolicy(name, conditionName, `group_exclude = ["readers"]`),
+				Check: resource.ComposeTestCheckFunc(
+					append(getSharedRepoVerification(),
+						resource.TestCheckResourceAttr(fqrn, "name", name),
+						resource.TestCheckResourceAttr(fqrn, "scope", "all_repos"),
+						resource.TestCheckResourceAttr(fqrn, "group_exclude.#", "1"),
+						resource.TestCheckTypeSetElemAttr(fqrn, "group_exclude.*", "readers"),
+						resource.TestCheckNoResourceAttr(fqrn, "group_include.#"),
+					)...,
+				),
+			},
+			{
+				// Step 3: Verify import round-trips group_exclude without drift
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test all_repos scope with user groups included in the policy scope (GH#434)
+func TestAccCurationPolicy_AllRepos_GroupInclude(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-all-repos-group-include", "xray_curation_policy")
+	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
+
+	sharedRepoConfig := getSharedRepoConfig()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        commonExternalProviders,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create shared repositories and verify they exist
+				Config: sharedRepoConfig,
+				Check:  resource.ComposeTestCheckFunc(getSharedRepoVerification()...),
+			},
+			{
+				// Step 2: Create the policy with a user group included in its scope
+				Config: sharedRepoConfig +
+					createGroupScopePolicy(name, conditionName, `group_include = ["readers"]`),
+				Check: resource.ComposeTestCheckFunc(
+					append(getSharedRepoVerification(),
+						resource.TestCheckResourceAttr(fqrn, "name", name),
+						resource.TestCheckResourceAttr(fqrn, "scope", "all_repos"),
+						resource.TestCheckResourceAttr(fqrn, "group_include.#", "1"),
+						resource.TestCheckTypeSetElemAttr(fqrn, "group_include.*", "readers"),
+						resource.TestCheckNoResourceAttr(fqrn, "group_exclude.#"),
+					)...,
+				),
+			},
+			{
+				// Step 3: Verify import round-trips group_include without drift
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Test all_repos scope with repository exclusions
 func TestAccCurationPolicy_AllRepos_WithExclusions(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-all-repos-exclude", "xray_curation_policy")

--- a/pkg/xray/resource/resource_xray_curation_policy_test.go
+++ b/pkg/xray/resource/resource_xray_curation_policy_test.go
@@ -499,6 +499,17 @@ func TestAccCurationPolicy_AllRepos_Manual_DecisionOwners(t *testing.T) {
 	})
 }
 
+// Group scope is resolved per requesting user, so Xray only honors it for packages
+// served from the cache: a policy with group_exclude or group_include is rejected
+// unless block_from_cache is true and the platform-level "Enable Curation for Cached
+// Packages" feature is on. That feature cannot be toggled via a public API, so the
+// group scope tests only run when XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED is set.
+func skipUnlessBlockFromCacheEnabled(t *testing.T) {
+	if os.Getenv("XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED") == "" {
+		t.Skipf("Env var XRAY_CURATION_BLOCK_FROM_CACHE_ENABLED is not set")
+	}
+}
+
 // Returns a policy configuration for the group scope tests, where groupAttr is
 // the group_exclude or group_include attribute under test.
 func createGroupScopePolicy(name string, conditionName string, groupAttr string) string {
@@ -509,6 +520,7 @@ func createGroupScopePolicy(name string, conditionName string, groupAttr string)
 			scope         = "all_repos"
 			policy_action = "block"
 			waiver_request_config = "forbidden"
+			block_from_cache = true
 			%s
 		}
 	`, name, name, conditionName, groupAttr)
@@ -516,6 +528,8 @@ func createGroupScopePolicy(name string, conditionName string, groupAttr string)
 
 // Test all_repos scope with user groups excluded from the policy scope (GH#434)
 func TestAccCurationPolicy_AllRepos_GroupExclude(t *testing.T) {
+	skipUnlessBlockFromCacheEnabled(t)
+
 	_, fqrn, name := testutil.MkNames("test-all-repos-group-exclude", "xray_curation_policy")
 	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
 
@@ -558,6 +572,8 @@ func TestAccCurationPolicy_AllRepos_GroupExclude(t *testing.T) {
 
 // Test all_repos scope with user groups included in the policy scope (GH#434)
 func TestAccCurationPolicy_AllRepos_GroupInclude(t *testing.T) {
+	skipUnlessBlockFromCacheEnabled(t)
+
 	_, fqrn, name := testutil.MkNames("test-all-repos-group-include", "xray_curation_policy")
 	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())
 


### PR DESCRIPTION
## Fix: [terraform-provider-xray] xray_curation_policy should support excluding user groups (GH#434)

Fixes [JTFPR-376](https://jfrog-int.atlassian.net/browse/JTFPR-376)

### Issue Details

- **Type:** feature
- **Source:** JIRA
- **Jira:** [JTFPR-376](https://jfrog-int.atlassian.net/browse/JTFPR-376)

### Problem

GitHub Issue
https://github.com/jfrog/terraform-provider-xray/issues/434
Triage Analysis
Classification: Feature Request
Priority: Medium
Root Cause
API exists but is not yet implemented in the provider. Run: ./sync-agent -provider <product> inspect to check API coverage.
Suggested Fix
1. Add new attribute(s) to existing schema

2. Update API model and fromAPIModel/toAPIModel mapping

3. Add acceptance tests for the new attribute(s)

4. Update CHANGELOG.md with fix entry

Related APIs
POST xray/api/v1/curation/policies

PUT xray/api/v1/curation/policies/{policy_id}

Affected Code
pkg/acctest/test.go

pkg/xray/resource/resource_xray_curation_policy.go

Labels
enhancement (newly applied)

priority:medium (newly applied)

Auto-created by terraform-provider-sync-agent triage command.

### Affected Resources

- `xray_curation_policy`

### Files Changed

- `pkg/xray/resource/resource_xray_curation_policy.go`
- `pkg/xray/resource/resource_xray_curation_policy_test.go`
- `docs/resources/curation_policy.md`
- `CHANGELOG.md`

### Analysis

## ROOT CAUSE

Not a defect — a **missing feature**. The Xray Curation Policy API (`POST`/`PUT xray/api/v1/curation/policies`) accepts optional `group_exclude` and `group_include` arrays (spec lines 16415–16430), but the provider never models them. They are absent from all four layers:

- **Model** `CurationPolicyResourceModel` (lines 293–309) — no field
- **API model** `CurationPolicyAPIModel` (lines 337–353) — no JSON tag
- **Schema** `Schema()` (lines 364–504) — no attribute
- **Mappers** `toAPIModel` (531–655) / `fromAPIModel` (657–813) — no conversion

Because the field never leaves `toAPIModel`, a user who wants to exclude user groups from a curation policy has no attribute to set. The issue title targets exclusion (`group_exclude`); since the spec exposes the symmetric pair and both are equally missing, add both.

Spec (source of truth):

```16415:16430:config/openapi/xray.yaml
        - name: group_exclude
          type: array
          required: false
          description: Groups to exclude from the policy scope.
          items:
            name: items
            type: string
            required: false
        - name: group_include
          type: array
          required: false
          description: Groups to include in the policy scope.
          items:
            name: items
            type: string
            required: false
```

Both are optional string arrays → `schema.SetAttribute{ElementType: types.StringType}` (mirrors `decision_owners`).

---

## FIX PLAN

**File:** `pkg/xray/resource/resource_xray_curation_policy.go`

1. **Model struct** — add two `types.Set` fields.
2. **API model** — add two `[]string` fields with `omitempty` (optional).
3. **Schema** — add two `SetAttribute`s (place beside `decision_owners`).
4. **`toAPIModel`** — convert plan sets → `[]string` (guard on `IsNull`).
5. **`fromAPIModel`** — convert API `[]string` → `types.Set` (guard on `len>0`, matching existing `decision_owners` pattern so an unset field stays null and doesn't cause drift).

No new validator needed — the spec places no scope constraint on these fields (unlike `repo_exclude`).

---

## CODE CHANGES

### 1. Model struct (lines 306–307)

```go
// Before:
	WaiverRequestConfig types.String `tfsdk:"waiver_request_config"`
	DecisionOwners      types.Set    `tfsdk:"decision_owners"`
	BlockFromCache      types.Bool   `tfsdk:"block_from_cache"`

// After:
	WaiverRequestConfig types.String `tfsdk:"waiver_request_config"`
	DecisionOwners      types.Set    `tfsdk:"decision_owners"`
	GroupExclude        types.Set    `tfsdk:"group_exclude"`
	GroupInclude        types.Set    `tfsdk:"group_include"`
	BlockFromCache      types.Bool   `tfsdk:"block_from_cache"`
```

### 2. API model (lines 349–351)

```go
// Before:
	WaiverRequestConfig string                  `json:"waiver_request_config,omitempty"`
	DecisionOwners      []string                `json:"decision_owners,omitempty"`
	BlockFromCache      bool                    `json:"block_from_cache"`

// After:
	WaiverRequestConfig string                  `json:"waiver_request_config,omitempty"`
	DecisionOwners      []string                `json:"decision_owners,omitempty"`
	GroupExclude        []string                `json:"group_exclude,omitempty"`
	GroupInclude        []string                `json:"group_include,omitempty"`
	BlockFromCache      bool                    `json:"block_from_cache"`
```

### 3. Schema — insert after the `decision_owners` attribute (after line 489)

```go
// Before:
			"decision_owners": schema.SetAttribute{
				Optional:    true,
				ElementType: types.StringType,
				Description: "List of JFrog Access groups used by waiver_request_config=manual",
			},
			"block_from_cache": schema.BoolAttribute{

// After:
			"decision_owners": schema.SetAttribute{
				Optional:    true,
				ElementType: types.StringType,
				Description: "List of JFrog Access groups used by waiver_request_config=manual",
			},
			"group_exclude": schema.SetAttribute{
				Optional:    true,
				ElementType: types.StringType,
				Description: "List of JFrog Access groups to exclude from the policy scope.",
			},
			"group_include": schema.SetAttribute{
				Optional:    true,
				ElementType: types.StringType,
				Description: "List of JFrog Access groups to include in the policy scope.",
			},
			"block_from_cache": schema.BoolAttribute{
```

### 4. `toAPIModel` — insert after the `decision_owners` conversion block (after line 589)

```go
// Before:
	// Convert decision_owners
	if !plan.DecisionOwners.IsNull() {
		var decisionOwners []string
		diags := plan.DecisionOwners.ElementsAs(ctx, &decisionOwners, false)
		if diags.HasError() {
			return diags
		}
		policy.DecisionOwners = decisionOwners
	}

	// Convert waivers

// After:
	// Convert decision_owners
	if !plan.DecisionOwners.IsNull() {
		var decisionOwners []string
		diags := plan.DecisionOwners.ElementsAs(ctx, &decisionOwners, false)
		if diags.HasError() {
			return diags
		}
		policy.DecisionOwners = decisionOwners
	}

	// Convert group_exclude
	if !plan.GroupExclude.IsNull() {
		var groupExclude []string
		diags := plan.GroupExclude.ElementsAs(ctx, &groupExclude, false)
		if diags.HasError() {
			return diags
		}
		policy.GroupExclude = groupExclude
	}

	// Convert group_include
	if !plan.GroupInclude.IsNull() {
		var groupInclude []string
		diags := plan.GroupInclude.ElementsAs(ctx, &groupInclude, false)
		if diags.HasError() {
			return diags
		}
		policy.GroupInclude = groupInclude
	}

	// Convert waivers
```

### 5. `fromAPIModel` — insert after the `decision_owners` conversion block (after line 726)

```go
// Before:
	if len(policy.DecisionOwners) > 0 {
		owners := make([]attr.Value, len(policy.DecisionOwners))
		for i, owner := range policy.DecisionOwners {
			owners[i] = types.StringValue(owner)
		}
		ownersSet, diags := types.SetValue(types.StringType, owners)
		if diags.HasError() {
			return diags
		}
		plan.DecisionOwners = ownersSet
	}

	// Convert waivers from API to Terraform model (only if present)

// After:
	if len(policy.DecisionOwners) > 0 {
		owners := make([]attr.Value, len(policy.DecisionOwners))
		for i, owner := range policy.DecisionOwners {
			owners[i] = types.StringValue(owner)
		}
		ownersSet, diags := types.SetValue(types.StringType, owners)
		if diags.HasError() {
			return diags
		}
		plan.DecisionOwners = ownersSet
	}

	if len(policy.GroupExclude) > 0 {
		groups := make([]attr.Value, len(policy.GroupExclude))
		for i, group := range policy.GroupExclude {
			groups[i] = types.StringValue(group)
		}
		groupExcludeSet, diags := types.SetValue(types.StringType, groups)
		if diags.HasError() {
			return diags
		}
		plan.GroupExclude = groupExcludeSet
	}

	if len(policy.GroupInclude) > 0 {
		groups := make([]attr.Value, len(policy.GroupInclude))
		for i, group := range policy.GroupInclude {
			groups[i] = types.StringValue(group)
		}
		groupIncludeSet, diags := types.SetValue(types.StringType, groups)
		if diags.HasError() {
			return diags
		}
		plan.GroupInclude = groupIncludeSet
	}

	// Convert waivers from API to Terraform model (only if present)
```

> **Drift note:** Guarding `fromAPIModel` on `len(...) > 0` (not writing an empty set) matches the existing `decision_owners`/`repo_exclude` behavior, so an unspecified `group_exclude` stays `null` and produces no spurious plan diff.

---

## TEST PLAN

**File:** `pkg/xray/resource/resource_xray_curation_policy_test.go` — add a test modeled on `TestAccCurationPolicy_AllRepos_WithExclusions` (line 503) using real Access groups (`readers`, like the `decision_owners` tests):

```go
func TestAccCurationPolicy_AllRepos_GroupExclude(t *testing.T) {
	_, fqrn, name := testutil.MkNames("test-group-exclude", "xray_curation_policy")
	conditionName := fmt.Sprintf("test-maturity-condition-%d", testutil.RandomInt())

	resource.Test(t, resource.TestCase{
		PreCheck:                 func() { acctest.PreCheck(t) },
		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
		ExternalProviders:        commonExternalProviders,
		CheckDestroy:             acctest.VerifyDeleted(fqrn, "", acctest.CheckCurationPolicy),
		Steps: []resource.TestStep{
			{
				// Step 1: create with group_exclude + group_include
				Config: createMaturityCondition(conditionName) + fmt.Sprintf(`
					resource "xray_curation_policy" "%s" {
						name          = "%s"
						condition_id  = xray_custom_curation_condition.%s.id
						scope         = "all_repos"
						policy_action = "dry_run"
						waiver_request_config = "forbidden"
						group_exclude = ["readers"]
						group_include = ["readers"]
					}
				`, name, name, conditionName),
				Check: resource.ComposeTestCheckFunc(
					resource.TestCheckResourceAttr(fqrn, "group_exclude.#", "1"),
					resource.TestCheckTypeSetElemAttr(fqrn, "group_exclude.*", "readers"),
					resource.TestCheckResourceAttr(fqrn, "group_include.#", "1"),
					resource.TestCheckTypeSetElemAttr(fqrn, "group_include.*", "readers"),
				),
			},
			{
				// Step 2: import round-trips the new attributes (no-diff)
				ResourceName:      fqrn,
				ImportState:       true,
				ImportStateVerify: true,
			},
		},
	})
}
```

Cases to cover:
1. **Create** with `group_exclude` set → assert count + element.
2. **Include pair** — same test asserts `group_include` too.
3. **Import** step (`ImportStateVerify: true`, default `id`) → verifies Read maps both fields back with no drift.
4. **Update lifecycle** (optional) — extend `TestAccCurationPolicy_CompleteUpdateLifecycle` (line 1193) to add/remove `group_exclude` and assert the change applies and re-plan is empty.
5. **Unset → null** — a config without the fields shows `group_exclude.#` absent and produces no diff on second plan.

**Also run `make doc`** — the two new attributes must appear in `docs/resources/curation_policy.md`.

---

## CHANGELOG ENTRY

This is a feature, so it belongs under an `IMPROVEMENTS`/`FEATURES` header rather than `BUG FIX`:

```
IMPROVEMENTS:
* resource/xray_curation_policy: Add `group_exclude` and `group_include` attributes to support excluding/including JFrog Access user groups from a curation policy scope. Issue: [434](https://github.com/jfrog/terraform-provider-xray/issues/434) PR: [NNN](https://github.com/jfrog/terraform-provider-xray/pull/NNN)
```

If you must keep the single-line format requested: `IMPROVEMENT: xray_curation_policy - add group_exclude/group_include for user group scope filtering (GH-434)`

---

Note: I'm in **Ask mode**, so this is analysis only — I haven't modified any files. Switch to Agent mode if you'd like me to apply these diffs, add the test, and run `make doc`.

### Changelog

```
## 3.1.15 (September 4, 2026)

IMPROVEMENTS:

* resource/xray_curation_policy: [terraform-provider-xray] xray_curation_policy should support excluding user groups

```

### Test Plan

- [ ] `go build ./...` passes
- [ ] Acceptance tests pass
- [ ] No state drift after apply + plan
- [ ] Import test verifies no diff

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Xray curation policies now support including or excluding JFrog Access user groups from policy scope.
  * Added `group_include` and `group_exclude` configuration options.
  * Group-based scope is resolved per requesting user, applies to cached packages, and requires `block_from_cache` to be enabled.

* **Documentation**
  * Updated curation policy documentation with group-scoping requirements.
  * Updated the version 3.1.14 changelog with the release date and enhancement details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->